### PR TITLE
prepare for deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ check [try.hyposfer.com](http://try.hiposfer.com/index.html)
 
 - locally
 
-
-    $ lein uberjar
-    $ java -jar target/kamal.jar
-
+```
+$ lein uberjar
+$ java -jar target/kamal.jar
+```
 
 - With Docker
 
 Grab the latest docker image and run it:
-
-    $ docker run -it -p 3000:3000 hiposfer/kamal
-
+```
+$ docker run -it -p 3000:3000 hiposfer/kamal
+```
 
 ### Development
 

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,9 @@
                              [io.aviso/pretty "0.1.34"]]}
              :uberjar {:aot [hiposfer.kamal.core] ;; compile the entry point and all of its dependencies}
                        :main hiposfer.kamal.core
-                       :uberjar-name "kamal.jar"}}
+                       :uberjar-name "kamal.jar"
+                       :jar-exclusions [#".*\.bz2"]
+                       :uberjar-exclusions [#".*\.bz2"]}}
                        ;:jvm-opts ["-Dclojure.compiler.direct-linking=true"]}}
   :test-selectors {:default (complement :benchmark)
                    :benchmark :benchmark}

--- a/resources/default-config.edn
+++ b/resources/default-config.edn
@@ -1,4 +1,4 @@
-{:osm-url "resources/osm/saarland.osm.bz2"
+{:osm-url "https://github.com/hiposfer/kamal/raw/master/resources/osm/saarland.osm.bz2"
  :port    3000}
 
 

--- a/resources/default-config.edn
+++ b/resources/default-config.edn
@@ -1,4 +1,4 @@
-{:osm-url "https://github.com/hiposfer/kamal/raw/master/resources/osm/saarland.osm.bz2"
+{:osm-url "resources/osm/saarland.osm.bz2"
  :port    3000}
 
 

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -40,12 +40,12 @@
   "reset the system to a fresh state. Prefer using this over go!"
   []
   (stop!)
-  (repl/refresh :after 'hiposfer.service.routing.dev/go!))
+  (repl/refresh :after 'hiposfer.kamal.dev/go!))
 
 ;(reset)
 
 ;(set! *print-length* 50)
-;@(:network (:grid system))
+;(take 10 @(:network (:grid system)))
 
 ;(System/gc)
 


### PR DESCRIPTION
fix: wrong namespace
fix: use remote file storage
fix: dont pack the OSM file in the uberjar
fix: github seems to have a slightly different markdown renderer