### PR TITLE
Problem: lein run does not work

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,6 +27,7 @@
                        ;:jvm-opts ["-Dclojure.compiler.direct-linking=true"]}}
   :test-selectors {:default (complement :benchmark)
                    :benchmark :benchmark}
+  :main hiposfer.kamal.core
   :global-vars {*warn-on-reflection* true}
   ;;FIXME: https://github.com/technomancy/leiningen/issues/2173
   :monkeypatch-clojure-test false


### PR DESCRIPTION
Solution: add main to the project file

`lein run` is a well known way to start any lein application. It is a surprise not to support it.