### PR TITLE
Problem: Github releases deploy does not work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ script:
 - lein clean
 - lein compile
 - lein check
-- lein eastwood '{:exclude-namespaces [hiposfer.kamal.graph.specs hiposfer.kamal.spec]}'
+- lein eastwood '{:exclude-namespaces [hiposfer.kamal.graph.specs hiposfer.kamal.spec]}'  
 - lein test
+- lein jar # produce jar files to deploy
 notifications:
   email:
     on_success: change
@@ -24,7 +25,8 @@ deploy:
 - provider: releases
   api_key:
     secure: lsXO5yrJEwt8NLYcpKjyxsPnx9m1bQ68lOFo15LhO5+BdBBOjqTU1/bgwOGfoTpFCaJ6F2jaC9oxqhDohHYSs8X70oNWK+quuNmbu237EOZrPm2pV5YE7H2PMcVuR+DpgPRc53AaJ+uEo/VEyuXA8d+p11kI+jXHf5rrRgMQI5pFUuXMKRl8bjGb7MB2P9DCn/LWIlXeRc8qI5SX7VjeK9oSJc6Pgbq61cN9s8mrookr8fIK/mJmc+SObv9QQHCWA1Xb+tV+iHRwomGj252mBwuzeRnkU91ObQ50vH1XCLN4HgU3pvt4stYWXtQl1N7CdmDx0liP7023RM2g7YAzNzU+oK8tav4HV+RjBWAKSNonPKgY3iD7h8JqJxLAdHcirD0UDp3bqiV4RiwMyu3b9mq5K9i69EgX3Lvy4l2ThYhwXAsqmnjzfCotm6qOJVpBwXmei01TL07xa+/Bu8SQaMdnte0T5macA5gZdEPDhNExbxDcjlOW1XedfQNW27R0Ja5vPz3nNQC4R7iE6Sa9WZ6nx8v0Vdgrv0U5hTVRHmDDhXmswLQekrko6TxuRGG0P+80fImjQafcccPO55e/7sNO+v/gBBpcXzTsNcdTgHUVhdH1wQItIGpSOGC3O4784NAtDnScMGfp7yFSmAHaoWm2fU1qFBqVGEaKGb3Fkfo=
-  file: target/kamal.jar
+  file_glob: true
+  file: target/kamal*.jar
   skip_cleanup: true
   on:
     branch: master


### PR DESCRIPTION
Solution: add `lein jar` to the build script and use wildcard to choose the right file for the release.

@carocad 
I think this should fix the GH deploy problem. Clojars should work fine, however I'm not sure what happens when `lein deploy` is called with the same non-snapshot version number? Will clojars reject the release and cause the build to fail? In that case we have to change the version to `SNAPSHOT` since it is always accepted with the same version number.