### PR TITLE
Routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ setting `:dev` to `false`.
 `kamal` is very routing oriented, thus no filtering is performed when reading
 OSM files. Dealing with unnecessary information in OSM files is left to the
 developer. If you dont want to create your own pre-processing script, we recommend
-you to use `Òverpass-Api`. [Here](http://overpass-turbo.eu/s/sHu) is an example
+you to use `Òverpass-Api`. [Here](resources/osm/overpass-api-query.txt) is an example
 query that we use to get only `pedestrian` relevant paths. You can customize it
 however you want; once you are done, click `Export` and get the `raw data directly from Overpass API` link;
  with it you can execute the query on a terminal or script.

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,6 @@
                  [org.apache.commons/commons-compress "1.4"] ;;bz2 files read
                  [org.clojure/data.avl "0.0.17"]
                  [org.teneighty/java-heaps "1.0.0"]
-                 [ch.hsr/geohash "1.3.0"]
                  [environ "1.1.0"]] ;; read environment variables from several sources
   :profiles {:dev {:dependencies [[criterium "0.4.4"]  ;; benchmark
                                   [expound "0.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.2.0"
+(defproject hiposfer/kamal "0.3.0"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"
@@ -16,6 +16,7 @@
                  [org.apache.commons/commons-compress "1.4"] ;;bz2 files read
                  [org.clojure/data.avl "0.0.17"]
                  [org.teneighty/java-heaps "1.0.0"]
+                 [ch.hsr/geohash "1.3.0"]
                  [environ "1.1.0"]] ;; read environment variables from several sources
   :profiles {:dev {:dependencies [[criterium "0.4.4"]  ;; benchmark
                                   [expound "0.1.1"]

--- a/resources/benchmark.txt
+++ b/resources/benchmark.txt
@@ -2,89 +2,89 @@
 Testing hiposfer.kamal.graph.benchmark
 
 
-DIJKSTRA forward with: 90397 nodes and 230142 edges
+DIJKSTRA forward with: 124163 nodes and 310040 edges
 saarland graph:
 amd64 Linux 4.4.0-97-generic 4 cpu(s)
 OpenJDK 64-Bit Server VM 25.131-b11
-Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/home/carocad/Proyectos/kamal/target/classes -Dkamal.version=0.2.0 -Dclojure.debug=false
-Evaluation count : 30 in 6 samples of 5 calls.
-      Execution time sample mean : 23,120231 ms
-             Execution time mean : 23,118922 ms
-Execution time sample std-deviation : 32,605253 µs
-    Execution time std-deviation : 38,541628 µs
-   Execution time lower quantile : 23,066503 ms ( 2,5%)
-   Execution time upper quantile : 23,162493 ms (97,5%)
-                   Overhead used : 1,474733 ns
+Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/home/carocad/Proyectos/kamal/target/classes -Dkamal.version=0.3.0 -Dclojure.debug=false
+Evaluation count : 12 in 6 samples of 2 calls.
+      Execution time sample mean : 56,240069 ms
+             Execution time mean : 56,243524 ms
+Execution time sample std-deviation : 188,359449 µs
+    Execution time std-deviation : 189,612600 µs
+   Execution time lower quantile : 56,080626 ms ( 2,5%)
+   Execution time upper quantile : 56,551895 ms (97,5%)
+                   Overhead used : 1,598161 ns
 
-Found 2 outliers in 6 samples (33,3333 %)
+Found 1 outliers in 6 samples (16,6667 %)
 	low-severe	 1 (16,6667 %)
-	low-mild	 1 (16,6667 %)
  Variance from outliers : 13,8889 % Variance is moderately inflated by outliers
 --------
 using only strongly connected components of the original graph
+with: 124163 nodes and 310040 edges
 amd64 Linux 4.4.0-97-generic 4 cpu(s)
 OpenJDK 64-Bit Server VM 25.131-b11
-Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/home/carocad/Proyectos/kamal/target/classes -Dkamal.version=0.2.0 -Dclojure.debug=false
-Evaluation count : 30 in 6 samples of 5 calls.
-      Execution time sample mean : 23,694615 ms
-             Execution time mean : 23,696072 ms
-Execution time sample std-deviation : 101,262839 µs
-    Execution time std-deviation : 105,249184 µs
-   Execution time lower quantile : 23,613606 ms ( 2,5%)
-   Execution time upper quantile : 23,854948 ms (97,5%)
-                   Overhead used : 1,474733 ns
+Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/home/carocad/Proyectos/kamal/target/classes -Dkamal.version=0.3.0 -Dclojure.debug=false
+Evaluation count : 12 in 6 samples of 2 calls.
+      Execution time sample mean : 56,319664 ms
+             Execution time mean : 56,319880 ms
+Execution time sample std-deviation : 107,544825 µs
+    Execution time std-deviation : 109,431372 µs
+   Execution time lower quantile : 56,234591 ms ( 2,5%)
+   Execution time upper quantile : 56,500835 ms (97,5%)
+                   Overhead used : 1,598161 ns
+
+Found 1 outliers in 6 samples (16,6667 %)
+	low-severe	 1 (16,6667 %)
+ Variance from outliers : 13,8889 % Variance is moderately inflated by outliers
 
 
-DIJKSTRA forward with: 1019 nodes and 6102 edges
+DIJKSTRA forward with: 1012 nodes and 6064 edges
 **random graph
 amd64 Linux 4.4.0-97-generic 4 cpu(s)
 OpenJDK 64-Bit Server VM 25.131-b11
-Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/home/carocad/Proyectos/kamal/target/classes -Dkamal.version=0.2.0 -Dclojure.debug=false
-Evaluation count : 546 in 6 samples of 91 calls.
-      Execution time sample mean : 1,109306 ms
-             Execution time mean : 1,109215 ms
-Execution time sample std-deviation : 1,640065 µs
-    Execution time std-deviation : 1,843373 µs
-   Execution time lower quantile : 1,106544 ms ( 2,5%)
-   Execution time upper quantile : 1,111243 ms (97,5%)
-                   Overhead used : 1,474733 ns
-
-Found 1 outliers in 6 samples (16,6667 %)
-	low-severe	 1 (16,6667 %)
- Variance from outliers : 13,8889 % Variance is moderately inflated by outliers
+Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/home/carocad/Proyectos/kamal/target/classes -Dkamal.version=0.3.0 -Dclojure.debug=false
+Evaluation count : 480 in 6 samples of 80 calls.
+      Execution time sample mean : 1,261930 ms
+             Execution time mean : 1,261982 ms
+Execution time sample std-deviation : 3,491633 µs
+    Execution time std-deviation : 3,662457 µs
+   Execution time lower quantile : 1,258102 ms ( 2,5%)
+   Execution time upper quantile : 1,266763 ms (97,5%)
+                   Overhead used : 1,598161 ns
 
 
 saarland graph: nearest neighbour search with random src/dst
-AVL tree with: 90397 nodes
-extra space required: 2.892704  MB
+AVL tree with: 124163 nodes
+extra space required: 3.973216  MB
 amd64 Linux 4.4.0-97-generic 4 cpu(s)
 OpenJDK 64-Bit Server VM 25.131-b11
-Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/home/carocad/Proyectos/kamal/target/classes -Dkamal.version=0.2.0 -Dclojure.debug=false
-Evaluation count : 750870 in 6 samples of 125145 calls.
-      Execution time sample mean : 797,823129 ns
-             Execution time mean : 797,777432 ns
-Execution time sample std-deviation : 2,825095 ns
-    Execution time std-deviation : 2,950269 ns
-   Execution time lower quantile : 794,550402 ns ( 2,5%)
-   Execution time upper quantile : 801,692292 ns (97,5%)
-                   Overhead used : 1,474733 ns
---------
-BRUTE force with: 90397 nodes
-amd64 Linux 4.4.0-97-generic 4 cpu(s)
-OpenJDK 64-Bit Server VM 25.131-b11
-Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/home/carocad/Proyectos/kamal/target/classes -Dkamal.version=0.2.0 -Dclojure.debug=false
-Evaluation count : 24 in 6 samples of 4 calls.
-      Execution time sample mean : 29,010126 ms
-             Execution time mean : 29,016351 ms
-Execution time sample std-deviation : 673,795193 µs
-    Execution time std-deviation : 676,425355 µs
-   Execution time lower quantile : 28,683950 ms ( 2,5%)
-   Execution time upper quantile : 30,175274 ms (97,5%)
-                   Overhead used : 1,474733 ns
+Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/home/carocad/Proyectos/kamal/target/classes -Dkamal.version=0.3.0 -Dclojure.debug=false
+Evaluation count : 793194 in 6 samples of 132199 calls.
+      Execution time sample mean : 758,290725 ns
+             Execution time mean : 758,393500 ns
+Execution time sample std-deviation : 8,288138 ns
+    Execution time std-deviation : 8,342109 ns
+   Execution time lower quantile : 753,384420 ns ( 2,5%)
+   Execution time upper quantile : 772,660872 ns (97,5%)
+                   Overhead used : 1,598161 ns
 
 Found 1 outliers in 6 samples (16,6667 %)
 	low-severe	 1 (16,6667 %)
  Variance from outliers : 13,8889 % Variance is moderately inflated by outliers
+--------
+BRUTE force with: 124163 nodes
+amd64 Linux 4.4.0-97-generic 4 cpu(s)
+OpenJDK 64-Bit Server VM 25.131-b11
+Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/home/carocad/Proyectos/kamal/target/classes -Dkamal.version=0.3.0 -Dclojure.debug=false
+Evaluation count : 18 in 6 samples of 3 calls.
+      Execution time sample mean : 38,492592 ms
+             Execution time mean : 38,492592 ms
+Execution time sample std-deviation : 139,296429 µs
+    Execution time std-deviation : 140,743797 µs
+   Execution time lower quantile : 38,397582 ms ( 2,5%)
+   Execution time upper quantile : 38,654482 ms (97,5%)
+                   Overhead used : 1,598161 ns
 
 Ran 3 tests containing 0 assertions.
 0 failures, 0 errors.

--- a/resources/osm/overpass-api-query.txt
+++ b/resources/osm/overpass-api-query.txt
@@ -1,10 +1,12 @@
 
-
 [out:xml][timeout:180];
 // get the specific search area
 {{geocodeArea:niederrad}}->.searchArea;
 // get all ways that are accessible to pedestrians
-way["access"!~"no|private"](area.searchArea)->.accessible;
+(
+	way["access"!~"no|private"](area.searchArea);
+  	way["foot"="yes"](area.searchArea);
+)->.accessible;
 
 // get all highways that can be traversed by pedestrian
 (

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -12,7 +12,7 @@
   "Constructs the current development system."
   []
   (alter-var-root #'system
-    (constantly (core/system (core/config {:dev false
+    (constantly (core/system (core/config {:dev true
                                            :join? false})))))
 
 (defn start!

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -2,8 +2,7 @@
   "Tools for interactive development with the REPL. This file should
   not be included in a production build of the application."
   (:require [com.stuartsierra.component :as component]
-            [environ.core :refer [env]]
-            [hiposfer.kamal.core :as routing]
+            [hiposfer.kamal.core :as core]
             [clojure.tools.namespace.repl :as repl]))
             ;[cheshire.core :as cheshire]))
 
@@ -13,8 +12,8 @@
   "Constructs the current development system."
   []
   (alter-var-root #'system
-    (constantly (routing/system (routing/config {:dev false
-                                                 :join? false})))))
+    (constantly (core/system (core/config {:dev false
+                                           :join? false})))))
 
 (defn start!
   "Starts the current development system."

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -13,7 +13,8 @@
   "Constructs the current development system."
   []
   (alter-var-root #'system
-    (constantly (routing/system (routing/config {:dev false})))))
+    (constantly (routing/system (routing/config {:dev false
+                                                 :join? false})))))
 
 (defn start!
   "Starts the current development system."

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -12,7 +12,7 @@
   "Constructs the current development system."
   []
   (alter-var-root #'system
-    (constantly (core/system (core/config {:dev true
+    (constantly (core/system (core/config {:dev false
                                            :join? false})))))
 
 (defn start!

--- a/src/hiposfer/kamal/directions.clj
+++ b/src/hiposfer/kamal/directions.clj
@@ -173,9 +173,9 @@
         start     (avl/nearest neighbours <= (first coordinates))
         dst       (avl/nearest neighbours <= (last coordinates))]
     (if (or (nil? start) (nil? dst)) {:code "NoSegment"}
-      (let [traversal (alg/dijkstra #(duration graph %1 %2)
-                                  #{(val start)}
-                                  (:graph network))
+      (let [traversal (alg/dijkstra (:graph network)
+                                    #(duration graph %1 %2)
+                                    #{(val start)})
             trace     (alg/shortest-path (val dst) traversal)]
         (if (nil? trace) {:code "NoRoute"}
           {:code "Ok"

--- a/src/hiposfer/kamal/directions.clj
+++ b/src/hiposfer/kamal/directions.clj
@@ -22,12 +22,13 @@
 
 (def ->coordinates (juxt rp/lon rp/lat))
 
+;; WARNING: we assume that we only traverse outgoing arcs
+;; and that there is only one arc connecting src & dst
 (defn- wayver
-  "get the way id based on the src/dst id of the traversed nodes"
-  [graph src dst]
-  (rp/way (reduce (fn [_ arc] (when (= dst (rp/dst arc)) (reduced arc)))
-                  nil
-                  (rp/successors (graph src)))))
+  "find the link that connects src and dst and returns it"
+  [graph src-trace dst-trace]
+  (some #(when (= (key dst-trace) (rp/dst %)) %)
+         (rp/successors (graph (key src-trace)))))
 
 
 (defn duration
@@ -40,58 +41,28 @@
                                (rp/lon dst) (rp/lat dst))]
     (/ length osm/walking-speed)))
 
-(defn- geometry
+(defn- linestring
   "get a geojson linestring based on the route path"
-  ([network trace]
-   (geometry network trace nil))
-  ([{:keys [graph]} trace last-id]
-    ;; include the last point in the geometry
-   (let [coordinates (transduce (comp (halt-when #(= (key %) last-id)
-                                        (fn [r h] (conj r (->coordinates (graph (key h))))))
-                                      (map key)
-                                      (map graph)
-                                      (map ->coordinates))
-                                conj
-                                []
-                                trace)]
-     {:type "LineString" ;; trace path is in reverse order so we need to order it
-      :coordinates (rseq coordinates)})))
-
-;; WARNING: we assume that we only traverse outgoing arcs
-;; and that there is only one arc connecting src & dst
-(defn- partition-by-street-name
-  "split the trace into a sequence of traces using the street name as separator"
-  [{:keys [graph ways]} trace]
-  (let [way-ids (map (fn [dst src] (wayver graph (key src) (key dst)))
-                     trace
-                     (rest trace))
-        ;; last: little hack to get the way of the first point
-        traces  (sequence (comp (map vector)
-                                (partition-by (fn [[_ id]] (:name (ways id))))
-                                (map #(map first %))) ;; get the path traces
-                          trace
-                          (concat way-ids [(last way-ids)]))
-        streets (sequence (comp (partition-by #(:name (ways %)))
-                                (map first)) ;; the first way id suffices
-                          way-ids)]
-        ;_ (println traces)]
-    (map vector streets traces)))
-
+  [{:keys [graph]} ids]
+  (let [coordinates (sequence (comp (map graph)
+                                    (map ->coordinates))
+                              ids)]
+    ;; ids is in reverse order so we need to order it
+    {:type "LineString"
+     :coordinates coordinates}))
 
 ;; https://www.mapbox.com/api-documentation/#stepmaneuver-object
 (defn- maneuver
   "returns a step manuever"
-  [{:keys [graph ways]}
-   [way-id-to trace-to :as destination]
-   [_ trace  :as origin]]
-  (let [location     (->coordinates (graph (key (first trace))))
-        pre-bearing  (math/bearing (->coordinates (graph (key (second trace))))
-                                   (->coordinates (graph (key (first trace)))))
-        post-bearing (math/bearing (->coordinates (graph (key (first trace))))
-                                   (->coordinates (graph (key (first trace-to)))))
+  [{:keys [graph ways]} prev-piece  piece next-piece]
+  (let [location     (->coordinates (graph (key (first (first piece)))))
+        pre-bearing  (math/bearing (graph (key (first (first prev-piece))))
+                                   (graph (key (first (first piece)))))
+        post-bearing (math/bearing (graph (key (first (first piece))))
+                                   (graph (key (first (first next-piece)))))
         angle        (mod (+ 360 (- post-bearing pre-bearing)) 360)
         modifier     (val (last (subseq bearing-turns <= angle)))
-        way-name     (:name (ways way-id-to))
+        way-name     (:name (ways (second (first piece))))
         instruction  (str "Take " modifier (when way-name (str " on " way-name)))]
     {:location location
      ;; todo: implement maneuver type
@@ -103,59 +74,66 @@
      :instruction    instruction}))
 
 ;https://www.mapbox.com/api-documentation/#routestep-object
-(defn- step
+(defn- step ;; piece => [[trace way] ...]
   "includes one StepManeuver object and travel to the following RouteStep"
-  [{:keys [ways] :as network}
-   [way-id-to trace-to :as destination]
-   [_ trace :as origin]]
-  (let [linestring (geometry network trace-to (key (first trace)))]
+  [{:keys [ways] :as network} prev-piece piece next-piece]
+  (let [linestring (linestring network (map (comp key first) (concat piece [(first next-piece)])))]
     {:distance (math/arc-length (:coordinates linestring))
-     :duration (- (rp/cost (val (first trace-to)))
-                  (rp/cost (val (first trace))))
+     :duration (- (val (first (first next-piece)))
+                  (val (first (first piece))))
      :geometry linestring
-     :name     (str (:name (ways way-id-to)))
+     :name     (str (:name (ways (second (first piece)))))
      :mode     "walking" ;;TODO this should not be hardcoded
-     :maneuver (maneuver network destination origin)
+     :maneuver (maneuver network prev-piece piece next-piece)
      :intersections []})) ;; TODO
 
+(defn- route-steps
+  "returns a route-steps vector or an empty vector if no steps are needed"
+  [network steps pieces]
+  (if (not steps) []
+    (let [;; add depart and arrival pieces into the calculation
+          pieces    (concat [(first pieces)] pieces [[(last (last pieces))]])
+          routes    (map step (repeat network) pieces (rest pieces) (rest (rest pieces)))
+          depart    (assoc-in (first routes) [:maneuver :type] "depart")
+          orig-last (last (butlast pieces))
+          arrive    (-> (step network orig-last (last pieces) (last pieces))
+                        (assoc-in     [:maneuver :type] "arrive"))]
+      (concat [depart] (rest routes) [arrive]))))
 
 ;https://www.mapbox.com/api-documentation/#routeleg-object
 (defn- route-leg
   "a route between only two waypoints
 
   WARNING: we dont support multiple waypoints yet !!"
-  [network steps trace]
-  (let [edge-case   (= 1 (count trace)) ;; happens when origin = destination
-        linestring  (geometry network trace)
-        ;; prevent computation when edge case
-        ways&traces (lazy-seq (partition-by-street-name network trace))]
-    {:distance     (math/arc-length (:coordinates linestring))
-     :duration     (rp/cost (val (first trace)))
-     ;; TODO: add depart and arrival steps
-     :steps        (if (or (not steps) edge-case) []
-                     (reverse (map step (repeat network)
-                                        ways&traces
-                                        (rest ways&traces))))
-     :summary      "" ;; TODO
-     :annotation   [] ;; TODO
-     :geometry     (if-not edge-case linestring
-                     (assoc linestring
-                            :coordinates
-                            (repeat 2 (first (:coordinates linestring)))))}))
+  [{:keys [graph ways] :as network} steps trail]
+  (let [way-ids     (sequence (comp (map (partial wayver graph))
+                                    (map rp/way))
+                              trail (rest trail))
+        ways&traces (map vector trail (concat way-ids [(last way-ids)]))
+        pieces      (partition-by #(:name (ways (second %))) ways&traces)]
+    {:distance   (math/arc-length (:coordinates (linestring network (map key trail))))
+     :duration   (rp/cost (val (last trail)))
+     :steps      (route-steps network steps pieces)
+     :summary    "" ;; TODO
+     :annotation []})) ;; TODO
 
 ;https://www.mapbox.com/api-documentation/#route-object
 (defn- route
   "a route through (potentially multiple) waypoints
 
   WARNING: we dont support multiple waypoints yet !!"
-  [network steps trace]
-  (let [leg       (route-leg network steps trace)]
-    {:geometry    (:geometry leg)
+  [network steps rtrail]
+  ;; a single trace is returned for src = dst
+  (let [trail (if (= 1 (count rtrail))
+                 (repeat 2 (first rtrail))
+                 (rseq (into [] rtrail)))
+        leg    (route-leg network steps trail)]
+    {:geometry    (linestring network (map key trail))
      :duration    (:duration leg)
      :distance    (:distance leg)
      :weight      (:duration leg)
      :weight_name "time"
-     :legs        [(dissoc leg :geometry)]}))
+     :legs        [leg]}))
 
 ;; for the time being we only care about the coordinates of start and end
 ;; but looking into the future it is good to make like this such that we
@@ -176,10 +154,10 @@
       (let [traversal (alg/dijkstra (:graph network)
                                     #(duration graph %1 %2)
                                     #{(val start)})
-            trace     (alg/shortest-path (val dst) traversal)]
-        (if (nil? trace) {:code "NoRoute"}
+            rtrail     (alg/shortest-path (val dst) traversal)]
+        (if (nil? rtrail) {:code "NoRoute"}
           {:code "Ok"
-           :routes [(route network steps trace)]
+           :routes [(route network steps rtrail)]
            :waypoints [{:name (str (:name (ways (some rp/way (rp/successors (key start))))))
                         :location (->coordinates (key start))}
                        {:name (str (:name (ways (some rp/way (rp/successors (key dst))))))

--- a/src/hiposfer/kamal/directions.clj
+++ b/src/hiposfer/kamal/directions.clj
@@ -24,7 +24,7 @@
 
 ;; WARNING: we assume that we only traverse outgoing arcs
 ;; and that there is only one arc connecting src & dst
-(defn- wayver
+(defn- link
   "find the link that connects src and dst and returns it"
   [graph src-trace dst-trace]
   (some #(when (= (key dst-trace) (rp/dst %)) %)
@@ -106,7 +106,7 @@
 
   WARNING: we dont support multiple waypoints yet !!"
   [{:keys [graph ways] :as network} steps trail]
-  (let [way-ids     (sequence (comp (map (partial wayver graph))
+  (let [way-ids     (sequence (comp (map (partial link graph))
                                     (map rp/way))
                               trail (rest trail))
         ways&traces (map vector trail (concat way-ids [(last way-ids)]))

--- a/src/hiposfer/kamal/directions.clj
+++ b/src/hiposfer/kamal/directions.clj
@@ -3,7 +3,8 @@
             [hiposfer.kamal.graph.algorithms :as alg]
             [hiposfer.kamal.graph.protocols :as rp]
             [hiposfer.kamal.libs.math :as math]
-            [clojure.data.avl :as avl]))
+            [clojure.data.avl :as avl]
+            [hiposfer.kamal.libs.tool :as tool]))
             ;[hiposfer.kamal.dev :as dev]))
             ;[cheshire.core :as cheshire]))
 
@@ -168,12 +169,10 @@
   (let [{:keys [coordinates steps radiuses alternatives language]} params
         start     (avl/nearest neighbours <= (first coordinates))
         dst       (avl/nearest neighbours <= (last coordinates))
-        traversal (alg/dijkstra (:graph network)
-                                :value-by #(duration graph %1 %2)
-                                :start-from #{(val start)})
-        trace     (reduce (fn [_ trace] (when (= (key (first trace)) (val dst))
-                                          (reduced trace)))
-                          nil traversal)]
+        traversal (alg/dijkstra #(duration graph %1 %2)
+                                #{(val start)}
+                                (:graph network))
+        trace     (alg/shortest-path (val dst) traversal)]
     (if (nil? trace)
       {:code "NoRoute"}
       {:code "Ok"

--- a/src/hiposfer/kamal/directions.clj
+++ b/src/hiposfer/kamal/directions.clj
@@ -3,9 +3,7 @@
             [hiposfer.kamal.graph.algorithms :as alg]
             [hiposfer.kamal.graph.protocols :as rp]
             [hiposfer.kamal.libs.math :as math]
-            [clojure.data.avl :as avl]
-            [hiposfer.kamal.libs.tool :as tool]))
-            ;[hiposfer.kamal.dev :as dev]))
+            [clojure.data.avl :as avl]))
             ;[cheshire.core :as cheshire]))
 
 ;; https://www.mapbox.com/api-documentation/#stepmaneuver-object
@@ -182,28 +180,14 @@
                    {:name (str (:name (ways (some rp/way (rp/successors (key dst))))))
                     :location (->coordinates (key dst))}]})))
 
-;(defonce network (time (update (time (osm/osm->network "resources/osm/saarland.osm"))
-;                               :graph
-;                               alg/biggest-component)))
-;
-;network
+;(def origin      (->coordinates (val (rand-nth (seq (:graph @(:network (:grid hiposfer.kamal.dev/system))))))))
+;(def destination (->coordinates (val (rand-nth (seq (:graph @(:network (:grid hiposfer.kamal.dev/system))))))))
 
-;(def origin [7.0016269 49.2373449])
-;(def destination [7.0240812 49.6021303])
-
-;(def origin      ((juxt rp/lon rp/lat) (val (rand-nth (seq (:graph network))))))
-;(def destination ((juxt rp/lon rp/lat) (val (rand-nth (seq (:graph network))))))
-;
-;(def result (direction network
-;                       :coordinates [origin destination]
-;                       :steps true))
-;
-;result
-;(:steps (first (:legs (first (:routes result)))))
+;(direction @(:network (:grid hiposfer.kamal.dev/system))
+;  :coordinates [origin destination]
+;  :steps true)
 ;
 ;(spit "resources/linestring.json"
 ;  (cheshire/generate-string (:geometry (first (:routes result)))))
 
-;(brute-nearest @(:network (:grid dev/system))
-;               {:lon 7.0288485, :lat 49.1064844}
-;               {:lon 6.957843, :lat 49.298881}})))
+;(keys (:grid dev/system))

--- a/src/hiposfer/kamal/graph/algorithms.clj
+++ b/src/hiposfer/kamal/graph/algorithms.clj
@@ -4,27 +4,44 @@
             [clojure.data.int-map :as imap]
             [clojure.set :as set]))
 
+
+(def movement
+  "mapping of direction to protocol functions for Link and Nodes"
+  {::forward  [rp/dst rp/successors]
+   ::backward [rp/src rp/predecessors]})
+
 (defn dijkstra
-  "returns a sequence of map-like entries which also implement the Traceable
-   protocol. The key of a map entry is the node id and its value is
-   a Valuable-protocol implementation returned by the cost function.
-   In other words something similar to [id {:cost number :time number}]
+  "returns a sequence of traversal-paths taken to reach each node. Each path is
+   composed of [key value] pairs with key=node-id, value=total-cost. See Dijkstra algorithm
 
   Parameters:
-   - :value-by is a function that takes an Arc and a Trace
+   - value-by is a function that takes an Arc and a Trace
                and returns a Valuable from src to dst
-   - :start-from is a set of node ids to start searching from
-   - :direction is one of ::forward or ::backward and determines whether
+   - start-from is a set of node ids to start searching from
+   - direction is one of ::forward or ::backward and determines whether
      to use the outgoing or incoming arcs of each node"
-  [graph & {:keys [start-from direction value-by]}]
-  (let [direction (or direction ::forward)
-        arcs (case direction ::forward  rp/successors
-                             ::backward rp/predecessors)
-        f    (case direction ::forward rp/dst
-                             ::backward rp/src)]
-    (route/->Dijkstra graph start-from value-by arcs f)))
+  ([value-by start-from graph]
+   (dijkstra value-by start-from ::forward graph))
+  ([value-by start-from direction graph]
+   (let [[f arcs] (movement direction)]
+     (route/->Dijkstra graph start-from value-by arcs f))))
 
-(def breath-first (constantly 1))
+(defn breath-first
+  "returns a sequence of traversal-paths taken to reach each node in the same
+  manner as Dijkstra algorithm but with a constant cost.
+
+  See Breath-first algorithm"
+  ([start-from graph]
+   (breath-first start-from ::forward graph))
+  ([start-from direction graph]
+   (dijkstra (constantly 1) start-from direction graph)))
+
+(defn shortest-path
+  "returns the path taken to reach dst using the provided graph traversal"
+  [dst-id graph-traversal]
+  (let [pred? (comp #{dst-id} key first)
+        rf    #(when (pred? %2) (reduced %2))]
+    (reduce rf nil graph-traversal)))
 
 (defn components
   "returns a lazy sequence of sets of nodes' ids of each strongly connected
@@ -33,9 +50,7 @@
   (lazy-seq
     (when (not-empty graph)
       (let [connected (sequence (comp (map first) (map key))
-                        (dijkstra graph
-                          :start-from #{(ffirst graph)}
-                          :value-by breath-first))
+                        (breath-first #{(ffirst graph)} graph))
             new-graph (reduce route/detach graph connected)]
         (cons connected (components new-graph))))))
 

--- a/src/hiposfer/kamal/graph/algorithms.clj
+++ b/src/hiposfer/kamal/graph/algorithms.clj
@@ -62,7 +62,7 @@
   [undirected-graph]
   (let [subsets   (components undirected-graph)
         connected (into (imap/int-set) (apply max-key count subsets))
-        ids       (into #{} (keys undirected-graph))]
+        ids       (into (imap/int-set) (keys undirected-graph))]
     (reduce route/detach
             undirected-graph
             (set/difference ids connected))))

--- a/src/hiposfer/kamal/graph/core.clj
+++ b/src/hiposfer/kamal/graph/core.clj
@@ -12,7 +12,7 @@
 ;; NOTE: for convenience we represent the edges as a directed outgoing arc
 ;;       and reverse it only if necessary (see predecesors)
 (defn edge? [coll] (and (satisfies? rp/Link coll)
-                        (satisfies? rp/UndirectedLink coll)))
+                        (satisfies? rp/Bidirectional coll)))
 
 (defn arc? [coll] (satisfies? rp/Link coll))
 
@@ -36,12 +36,17 @@
   [graph]
   (sequence (mapcat rp/predecessors) (vals graph)))
 
-;; TODO: the edges protocol should not exist. It should be possible to
-;; achieve the same behavior with sucessors + edge? + mirror?
 (defn edges
-  "returns a lazy sequence of bidirectional arcs (those that conform to edge?)"
-  [graph]
-  (sequence (mapcat rp/edges) (vals graph)))
+  "returns a lazy sequence of bidirectional arcs (those that conform to edge?)
+  in their original direction i.e. no mirrored Links are returned. The order
+  of the elements is not guaranteed"
+  ([graph]
+   (sequence (mapcat edges) (repeat graph) (keys graph)))
+  ([graph node-id]
+   (sequence (comp (map rp/successors)
+                   (filter edge?)
+                   (map #(if (rp/mirror? %) (rp/mirror %) %)))
+             (graph node-id))))
 
 (defn connect
   "connect the nodes src and dst of link"
@@ -78,24 +83,24 @@
 ; graph is an {id node}
 ; NodeInfo is a {:lon :lat :links {node-id arc}}
 ; Arc is a {:src :dst :way-id}
-
-;; TODO: do I need the :mirror? flag?
 (defrecord Edge [^long src ^long dst ^long way]
   rp/Link
   (src [_] src)
   (dst [_] dst)
   rp/Passage
   (way [_] way)
-  rp/UndirectedLink
-  (mirror [_] (map->Edge {:src dst :dst src :way way}))) ;:mirror? true}))
-  ;(mirror? [this] (:mirror? this))
+  rp/Bidirectional
+  (mirror [this]
+    (if (:mirror? this)
+      (dissoc this :mirror?) ; remove mirror from edge
+      (map->Edge {:src dst :dst src :way way :mirror? true})))
+  (mirror? [this] (:mirror? this)))
 
 
 (defrecord Arc [^long src ^long dst ^long way]
   rp/Link
   (src [_] src)
   (dst [_] dst)
-  ;(mirror? [this] (:mirror? this))
   rp/Passage
   (way [_] way))
 
@@ -111,9 +116,6 @@
                                                (map rp/mirror))
                                          (vals (:incoming this)))
                                (vals (:outgoing this))))
-  (edges [this] (sequence (filter edge?)
-                          (concat (vals (:incoming this))
-                                  (vals (:outgoing this)))))
   rp/GeoCoordinate
   (lat [_] lat)
   (lon [_] lon)
@@ -152,9 +154,6 @@
                                                (map rp/mirror))
                                          (vals (:incoming this)))
                                (vals (:outgoing this))))
-  (edges [this] (sequence (filter edge?)
-                          (concat (:incoming this)
-                                  (:outgoing this))))
   rp/GeoCoordinate
   (lat [this] (:lat this))
   (lon [this] (:lon this))
@@ -171,10 +170,6 @@
   rp/Link
   (src [this] (:src this))
   (dst [this] (:dst this))
-  (mirror [this] (assoc this :src (:dst this)
-                             :dst (:src this)))
-                             ;:mirror? true))
-  ;(mirror? [this] (:mirror? this))
   rp/Passage
   (way [this] (:way this)))
 
@@ -213,7 +208,8 @@
   the queue or adds it otherwise"
   [value f ^Map settled ^Map unsettled ^Heap$Entry entry ^Heap queue trail node-arcs]
   (if (empty? node-arcs) nil
-    (if (.containsKey settled (f (first node-arcs))) nil
+    (if (.containsKey settled (f (first node-arcs)))
+      (recur value f settled unsettled entry queue trail (rest node-arcs))
       (let [arc     (first node-arcs)
             prev-id (key (.getValue entry))
             weight  (rp/sum (value arc trail)
@@ -299,7 +295,7 @@
              trail (produce! graph value arcs f queue settled unsettled)]
         (let [rr (rf ret trail)]
           (if (reduced? rr) @rr
-            (if (.isEmpty queue) ret
+            (if (.isEmpty queue) rr
               (recur rr (produce! graph value arcs f queue settled unsettled))))))))
   ;; ------
   IReduce

--- a/src/hiposfer/kamal/graph/core.clj
+++ b/src/hiposfer/kamal/graph/core.clj
@@ -36,6 +36,8 @@
   [graph]
   (sequence (mapcat rp/predecessors) (vals graph)))
 
+;; TODO: the edges protocol should not exist. It should be possible to
+;; achieve the same behavior with sucessors + edge? + mirror?
 (defn edges
   "returns a lazy sequence of bidirectional arcs (those that conform to edge?)"
   [graph]

--- a/src/hiposfer/kamal/graph/core.clj
+++ b/src/hiposfer/kamal/graph/core.clj
@@ -43,10 +43,9 @@
   ([graph]
    (sequence (mapcat edges) (repeat graph) (keys graph)))
   ([graph node-id]
-   (sequence (comp (map rp/successors)
-                   (filter edge?)
+   (sequence (comp (filter edge?)
                    (map #(if (rp/mirror? %) (rp/mirror %) %)))
-             (graph node-id))))
+             (rp/successors (graph node-id)))))
 
 (defn connect
   "connect the nodes src and dst of link"

--- a/src/hiposfer/kamal/graph/protocols.clj
+++ b/src/hiposfer/kamal/graph/protocols.clj
@@ -23,13 +23,13 @@
   (src [this] "the start node id of a Link")
   (dst [this] "the destination node id of a Link"))
 
+(defprotocol Bidirectional
+  (mirror [this] "returns a Link in the opposite direction of the original.
+                  (= (mirror (mirror edge)) edge)")
+  (mirror? [this] "returns a true if this Link is a mirror copy of the original"))
+
 (defprotocol Passage
   (way [this] "return the way id that a Link is associated with"))
-
-(defprotocol UndirectedLink
-  (mirror [this] "returns an UndirectedLink in the opposite direction than the original"))
-  ;(mirror? [this]))
-
 
 ;; ------- protocols for Nodes
 (defprotocol Context

--- a/src/hiposfer/kamal/libs/math.clj
+++ b/src/hiposfer/kamal/libs/math.clj
@@ -60,7 +60,7 @@
 ; http://www.movable-type.co.uk/scripts/latlong.html
 (defn bearing
   "return a Number between 0 and 360 indicating the clockwise angle from true
-   north to the direction of travel right before the maneuver"
+   north to the direction of travel (p1 -> p2)"
   [p1 p2]
   (let [φ1 (Math/toRadians (rp/lat p1))
         φ2 (Math/toRadians (rp/lat p2))

--- a/src/hiposfer/kamal/libs/math.clj
+++ b/src/hiposfer/kamal/libs/math.clj
@@ -1,6 +1,5 @@
 (ns hiposfer.kamal.libs.math
-  (:require [hiposfer.kamal.graph.protocols :as rp])
-  (:import (ch.hsr.geohash GeoHash)))
+  (:require [hiposfer.kamal.graph.protocols :as rp]))
 
 ;; Note in these scripts, I generally use
 ;; - latitude, longitude in degrees
@@ -73,12 +72,13 @@
     (rem (+ (Math/toDegrees (Math/atan2 y x)) 360)
          360)));
 
-;;TODO how much precision do I need for the geohash?
+;; TODO: consider using geohashes
+;; http://www.bigfastblog.com/geohash-intro
 (defn lexicographic-coordinate
   "comparator function to order nodes in a graph
   WARNING: this assumes that two points cannot occupy the same
   space. e.g. no 3D points since two point with different height
   but equal lat, lon would collide"
   [x y]
-  (compare (GeoHash/withBitPrecision (rp/lat x) (rp/lon x) 32)
-           (GeoHash/withBitPrecision (rp/lat y) (rp/lon y) 32)))
+  (compare [(rp/lat x) (rp/lon x)]
+           [(rp/lat y) (rp/lon y)]))

--- a/src/hiposfer/kamal/libs/math.clj
+++ b/src/hiposfer/kamal/libs/math.clj
@@ -1,5 +1,6 @@
 (ns hiposfer.kamal.libs.math
-  (:require [hiposfer.kamal.graph.protocols :as rp]))
+  (:require [hiposfer.kamal.graph.protocols :as rp])
+  (:import (ch.hsr.geohash GeoHash)))
 
 ;; Note in these scripts, I generally use
 ;; - latitude, longitude in degrees
@@ -72,11 +73,12 @@
     (rem (+ (Math/toDegrees (Math/atan2 y x)) 360)
          360)));
 
+;;TODO how much precision do I need for the geohash?
 (defn lexicographic-coordinate
   "comparator function to order nodes in a graph
   WARNING: this assumes that two points cannot occupy the same
   space. e.g. no 3D points since two point with different height
   but equal lat, lon would collide"
   [x y]
-  (compare [(rp/lat x) (rp/lon x)]
-           [(rp/lat y) (rp/lon y)]))
+  (compare (GeoHash/withBitPrecision (rp/lat x) (rp/lon x) 32)
+           (GeoHash/withBitPrecision (rp/lat y) (rp/lon y) 32)))

--- a/src/hiposfer/kamal/libs/tool.clj
+++ b/src/hiposfer/kamal/libs/tool.clj
@@ -35,3 +35,12 @@
   ([f coll] (map (fn [[k v]] [k (f v)])
                  coll))
   ([f] (map (fn [[k v]] [k (f v)]))))
+
+(defn some*
+  "an alternative version of Clojure's some which uses reduce instead of
+  recur. Useful for collections that know how to reduce themselves faster
+  than first/next"
+  [pred? coll]
+  (reduce (fn [_ value] (when (pred? value) (reduced value)))
+          nil
+          coll))

--- a/src/hiposfer/kamal/osm.clj
+++ b/src/hiposfer/kamal/osm.clj
@@ -143,11 +143,12 @@
         nodes         (apply dissoc points&nodes (keys points))
         nodes         (into nodes (tool/map-vals route/map->NodeInfo)
                                   nodes)
-        graph         (alg/biggest-component (reduce graph/connect nodes edges))
+        graph         (reduce graph/connect nodes edges)
         neighbours    (into (avl/sorted-map-by math/lexicographic-coordinate)
                             (set/map-invert graph))]
-    {:ways   ways   :graph graph
-     :points points
+    {:ways  ways
+     :graph graph
+     ;;:points points TODO enable them later to improve precision
      :neighbours neighbours}))
 
 (def walking-speed  2.5);; m/s

--- a/src/hiposfer/kamal/osm.clj
+++ b/src/hiposfer/kamal/osm.clj
@@ -147,7 +147,7 @@
         neighbours    (into (avl/sorted-map-by math/lexicographic-coordinate)
                             (set/map-invert graph))]
     {:ways   ways   :graph graph
-     ;:points points ;; TODO reactivate them for better geometry precision.
+     :points points
      :neighbours neighbours}))
 
 (def walking-speed  2.5);; m/s

--- a/src/hiposfer/kamal/server.clj
+++ b/src/hiposfer/kamal/server.clj
@@ -28,9 +28,9 @@
                   :data {:info {:title "Routing API"
                                 :description "Routing for hippos"}
                          :tags [{:name "direction", :description "direction similar to mabbox"}]}}}
-    (GET "/spec/direction/:coordinates" []
+    (GET "/directions/v5/:coordinates" []
       :coercion :spec
-      :summary "direction with clojure.spec"
+      :summary "directions with clojure.spec"
       :path-params [coordinates :- ::spec/raw-coordinates]
       :query-params [{steps :- boolean? false}
                      {radiuses :- ::spec/raw-radiuses nil}

--- a/test/hiposfer/kamal/graph/benchmark.clj
+++ b/test/hiposfer/kamal/graph/benchmark.clj
@@ -22,13 +22,8 @@
              (reduce + (map (comp count rp/successors) (vals graph))) "edges")
     (println "**random graph")
     (c/quick-bench
-      (let [coll (alg/dijkstra graph
-                   :start-from #{src}
-                   :value-by (partial direction/duration graph))]
-        (reduce (fn [_ v] (when (= dst (key (first v)))
-                            (reduced v)))
-                nil
-                coll))
+      (let [coll (alg/dijkstra (partial direction/duration graph) #{src} graph)]
+        (alg/shortest-path dst coll))
       :os :runtime :verbose)))
 
 (def networker (delay (osm/osm->network "resources/osm/saarland.min.osm.bz2")))
@@ -45,24 +40,14 @@
              (reduce + (map (comp count rp/successors) (vals graph))) "edges")
     (println "saarland graph:")
     (c/quick-bench
-      (let [coll (alg/dijkstra graph
-                   :start-from #{src}
-                   :value-by (partial direction/duration graph))]
-        (reduce (fn [_ v] (when (= dst (key (first v)))
-                            (reduced v)))
-                nil
-                coll))
+      (let [coll (alg/dijkstra (partial direction/duration graph) #{src} graph)]
+        (alg/shortest-path dst coll))
       :os :runtime :verbose)
     (println "--------")
     (println "using only strongly connected components of the original graph")
     (c/quick-bench
-      (let [coll (alg/dijkstra Cgraph
-                   :start-from #{src}
-                   :value-by (partial direction/duration Cgraph))]
-        (reduce (fn [_ v] (when (= dst (key (first v)))
-                            (reduced v)))
-                nil
-                coll))
+      (let [coll (alg/dijkstra (partial direction/duration Cgraph) #{src} Cgraph)]
+        (alg/shortest-path dst coll))
       :os :runtime :verbose)))
 
 (defn- brute-nearest

--- a/test/hiposfer/kamal/graph/benchmark.clj
+++ b/test/hiposfer/kamal/graph/benchmark.clj
@@ -22,7 +22,7 @@
              (count (graph/edges graph)) "edges")
     (println "**random graph")
     (c/quick-bench
-      (let [coll (alg/dijkstra (partial direction/duration graph) #{src} graph)]
+      (let [coll (alg/dijkstra graph (partial direction/duration graph) #{src})]
         (alg/shortest-path dst coll))
       :os :runtime :verbose)))
 
@@ -40,7 +40,7 @@
              (count (graph/edges graph)) "edges")
     (println "saarland graph:")
     (c/quick-bench
-      (let [coll (alg/dijkstra (partial direction/duration graph) #{src} graph)]
+      (let [coll (alg/dijkstra graph (partial direction/duration graph) #{src})]
         (alg/shortest-path dst coll))
       :os :runtime :verbose)
     (println "--------")
@@ -48,7 +48,7 @@
     (println "with:" (count Cgraph) "nodes and"
              (count (graph/edges Cgraph)) "edges")
     (c/quick-bench
-      (let [coll (alg/dijkstra (partial direction/duration Cgraph) #{src} Cgraph)]
+      (let [coll (alg/dijkstra Cgraph (partial direction/duration Cgraph) #{src})]
         (alg/shortest-path dst coll))
       :os :runtime :verbose)))
 

--- a/test/hiposfer/kamal/graph/benchmark.clj
+++ b/test/hiposfer/kamal/graph/benchmark.clj
@@ -6,9 +6,9 @@
             [hiposfer.kamal.graph.algorithms :as alg]
             [hiposfer.kamal.osm :as osm]
             [hiposfer.kamal.directions :as direction]
-            [hiposfer.kamal.graph.protocols :as rp]
             [hiposfer.kamal.libs.math :as math]
-            [clojure.data.avl :as avl]))
+            [clojure.data.avl :as avl]
+            [hiposfer.kamal.graph.core :as graph]))
 
 ;; This is just to show the difference between a randomly generated graph
 ;; and a real-world graph. The randomly generated graph does not have a structure
@@ -19,7 +19,7 @@
         src          (key (first graph))
         dst          (key (last graph))]
     (println "\n\nDIJKSTRA forward with:" (count graph) "nodes and"
-             (reduce + (map (comp count rp/successors) (vals graph))) "edges")
+             (count (graph/edges graph)) "edges")
     (println "**random graph")
     (c/quick-bench
       (let [coll (alg/dijkstra (partial direction/duration graph) #{src} graph)]
@@ -37,7 +37,7 @@
         src          (key (first Cgraph))
         dst          (key (last Cgraph))]
     (println "\n\nDIJKSTRA forward with:" (count graph) "nodes and"
-             (reduce + (map (comp count rp/successors) (vals graph))) "edges")
+             (count (graph/edges graph)) "edges")
     (println "saarland graph:")
     (c/quick-bench
       (let [coll (alg/dijkstra (partial direction/duration graph) #{src} graph)]
@@ -45,6 +45,8 @@
       :os :runtime :verbose)
     (println "--------")
     (println "using only strongly connected components of the original graph")
+    (println "with:" (count Cgraph) "nodes and"
+             (count (graph/edges Cgraph)) "edges")
     (c/quick-bench
       (let [coll (alg/dijkstra (partial direction/duration Cgraph) #{src} Cgraph)]
         (alg/shortest-path dst coll))

--- a/test/hiposfer/kamal/graph/tests.clj
+++ b/test/hiposfer/kamal/graph/tests.clj
@@ -8,36 +8,37 @@
             [hiposfer.kamal.graph.generators :as g]
             [hiposfer.kamal.directions :as direction]
             [hiposfer.kamal.graph.core :as route]
-            [hiposfer.kamal.libs.tool :as tool]))
+            [clojure.data.int-map :as imap]
+            [hiposfer.kamal.graph.core :as graph]))
 
 ;; https://rosettacode.org/wiki/Dijkstra%27s_algorithm
-(def rosetta {1 {:outgoing {2 {:dst 2 :length 7}
-                            3 {:dst 3 :length 9}
-                            6 {:dst 6 :length 14}}}
-              2 {:outgoing {3 {:dst 3 :length 10}
-                            4 {:dst 4 :length 15}}
-                 :incoming {1 {:src 1 :length 7}}}
-              3 {:outgoing {4 {:dst 4 :length 11}
-                            6 {:dst 6 :length 2}}
-                 :incoming {1 {:src 1 :length 9}
-                            2 {:src 2 :length 10}}}
-              4 {:outgoing {5 {:dst 5 :length 6}}
-                 :incoming {2 {:src 2 :length 15}
-                            3 {:src 3 :length 11}}}
-              5 {:outgoing {6 {:dst 6 :length 9}}
-                 :incoming {4 {:src 4 :length 6}}}
-              6 {:incoming {1 {:src 1 :length 14}
-                            3 {:src 3 :length 2}
-                            5 {:src 5 :length 9}}}})
+(def rosetta {1 {:outgoing {2 {:src 1 :dst 2 :length 7}
+                            3 {:src 1 :dst 3 :length 9}
+                            6 {:src 1 :dst 6 :length 14}}}
+              2 {:outgoing {3 {:src 2 :dst 3 :length 10}
+                            4 {:src 2 :dst 4 :length 15}}
+                 :incoming {1 {:src 1 :dst 2 :length 7}}}
+              3 {:outgoing {4 {:src 3 :dst 4 :length 11}
+                            6 {:src 3 :dst 6 :length 2}}
+                 :incoming {1 {:src 1 :dst 3 :length 9}
+                            2 {:src 2 :dst 3 :length 10}}}
+              4 {:outgoing {5 {:src 4 :dst 5 :length 6}}
+                 :incoming {2 {:src 2 :dst 4 :length 15}
+                            3 {:src 3 :dst 4 :length 11}}}
+              5 {:outgoing {6 {:src 5 :dst 6 :length 9}}
+                 :incoming {4 {:src 4 :dst 5 :length 6}}}
+              6 {:incoming {1 {:src 1 :dst 6 :length 14}
+                            3 {:src 3 :dst 6 :length 2}
+                            5 {:src 5 :dst 6 :length 9}}}})
 
 ;Distances from 1: ((1 0) (2 7) (3 9) (4 20) (5 26) (6 11))
 ;Shortest path: (1 3 4 5)
 
 (deftest shortest-path
   (let [dst       5
-        performer (alg/dijkstra (fn [arc _] (:length arc))
-                                #{1}
-                                rosetta)
+        performer (alg/dijkstra rosetta
+                                (fn [arc _] (:length arc))
+                                #{1})
         traversal (alg/shortest-path dst performer)]
     (is (not (empty? traversal))
         "shortest path not found")
@@ -45,9 +46,9 @@
         "shortest path doesnt traverse expected nodes")))
 
 (deftest all-paths
-  (let [performer (alg/dijkstra (fn length [arc _] (:length arc))
-                                #{1}
-                                rosetta)
+  (let [performer (alg/dijkstra rosetta
+                                (fn length [arc _] (:length arc))
+                                #{1})
         traversal (into {} (comp (map first)
                                  (map (juxt key (comp rp/cost val))))
                            performer)]
@@ -66,9 +67,9 @@
   (prop/for-all [graph (gen/such-that not-empty (g/graph 10) 1000)]
     (let [src  (rand-nth (keys graph))
           dst  (rand-nth (keys graph))
-          coll (alg/dijkstra (partial direction/duration graph)
-                             #{src}
-                             graph)
+          coll (alg/dijkstra graph
+                             (partial direction/duration graph)
+                             #{src})
           results (for [_ (range 10)]
                     (alg/shortest-path dst coll))]
       (or (every? nil? results)
@@ -83,9 +84,9 @@
   (prop/for-all [graph (gen/such-that not-empty (g/graph 10) 1000)]
     (let [src    (rand-nth (keys graph))
           dst    (rand-nth (keys graph))
-          coll   (alg/dijkstra (partial direction/duration graph)
-                               #{src}
-                               graph)
+          coll   (alg/dijkstra graph
+                               (partial direction/duration graph)
+                               #{src})
           result (alg/shortest-path dst coll)]
       (is (or (nil? result)
               (apply >= (concat (map (comp rp/cost val) result)
@@ -100,9 +101,9 @@
   100; tries
   (prop/for-all [graph (gen/such-that not-empty (g/graph 10) 1000)]
     (let [src  (rand-nth (keys graph))
-          coll (alg/dijkstra (partial direction/duration graph)
-                             #{src}
-                             graph)
+          coll (alg/dijkstra graph
+                             (partial direction/duration graph)
+                             #{src})
           result (alg/shortest-path src coll)]
       (is (not-empty result)
           "no path from node to himself found")
@@ -132,9 +133,9 @@
   (prop/for-all [graph (gen/such-that not-empty (g/graph 10) 1000)]
     (let [graph2 (alg/biggest-component graph)
           src    (key (first graph2))
-          coll   (alg/dijkstra (partial direction/duration graph2)
-                               #{src}
-                               graph2)]
+          coll   (alg/dijkstra graph2
+                               (partial direction/duration graph2)
+                               #{src})]
       (is (seq? (reduce (fn [r v] v) nil coll))
           "biggest components should not contain links to nowhere"))))
 


### PR DESCRIPTION
@mehdisadeghi as always, little bugs turned into big PR

This PR has the following changes:
- fix bug: `dijkstra` was ignoring the nodes arcs if one of them was already settled; this was weird enough that it wasnt caught by any tests :(
- fix bug: `dijkstra` was discarding the last computation when the sequence was empty; also not caught by the tests since somehow, sometimes the value was added even if it wasnt returned. 
- fix: `overpass-api` query to include `foot` access
- fix: `directions` endpoint according to the new Clojure api from previous PR.
- fix: `depart` and `arrive` instructions added to `directions` steps
- `breath-first` and `shortest-path` functions added to improve readability.
- fix: `biggest-component` performance issues
- fix: `Edges` api. Now `edges` are a function for both graph and nodes. `mirror?` function added to `Bidirectional` protocol to be able to filter out "virtual edges".
- fix: osm read performance issues
- `dijkstra` api changed to be more "Clojurist"

The `dijkstra` fixes unfortunately means that now it is slower as before since all arcs are explored.