### PR TITLE
route handlers

### DIFF
--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -6,7 +6,7 @@
             [clojure.tools.namespace.repl :as repl]))
             ;[cheshire.core :as cheshire]))
 
-(defonce system nil)
+(def system nil)
 
 (defn init!
   "Constructs the current development system."
@@ -28,8 +28,7 @@
 (defn go!
   "Initializes the current development system and starts it running."
   []
-  (when system ;; prevent leaking resources if already started
-    (stop!))
+  (stop!)
   (init!)
   (start!))
 

--- a/src/hiposfer/kamal/server.clj
+++ b/src/hiposfer/kamal/server.clj
@@ -20,6 +20,7 @@
   (map edn/read-string (str/split text #";")))
 ;(->radiuses "1200.50;100;500;unlimited;100")
 
+;; ring handlers are matched in order
 (defn create
   "creates an API handler with a closure around the grid"
   [grid]
@@ -56,6 +57,7 @@
                              :radiuses radiuses
                              :alternatives alternatives
                              :language language)))))
-    (GET "/*" [] (not-found (ok {:not "found"})))))
+    ;; if nothing else matched, return a 404 - not found
+    (ANY "/*" [] (not-found "we couldnt find what you were looking for"))))
 
 ;(:app hiposfer.kamal.dev/system)

--- a/src/hiposfer/kamal/server.clj
+++ b/src/hiposfer/kamal/server.clj
@@ -1,6 +1,6 @@
 (ns hiposfer.kamal.server
-  (:require [ring.util.http-response :refer [ok]]
-            [compojure.api.sweet :refer [context GET api]]
+  (:require [ring.util.http-response :refer [ok not-found]]
+            [compojure.api.sweet :refer [context GET api ANY undocumented]]
             [hiposfer.kamal.spec :as spec]
             [hiposfer.kamal.directions :as dir]
             [hiposfer.kamal.graph.generators :as g]
@@ -27,7 +27,8 @@
                   :spec "/swagger.json"
                   :data {:info {:title "Routing API"
                                 :description "Routing for hippos"}
-                         :tags [{:name "direction", :description "direction similar to mabbox"}]}}}
+                         :tags [{:name "direction", :description "direction similar to mabbox"}]}}
+        :api {:invalid-routes-fn compojure.api.routes/fail-on-invalid-child-routes}}
     (GET "/directions/v5/:coordinates" []
       :coercion :spec
       :summary "directions with clojure.spec"
@@ -54,4 +55,7 @@
                              :steps steps
                              :radiuses radiuses
                              :alternatives alternatives
-                             :language language)))))))
+                             :language language)))))
+    (GET "/*" [] (not-found (ok {:not "found"})))))
+
+;(:app hiposfer.kamal.dev/system)


### PR DESCRIPTION
- fix: null pointer exception if no matching handler was found
- fix: apparent memory leak when `reset` executed around 5 times
- fix: throw an exception at compile time if the routes do not comply with ring specification