### PR TITLE
fix: src=dst exception

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.3.2"
+(defproject hiposfer/kamal "0.3.3"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"

--- a/src/hiposfer/kamal/directions.clj
+++ b/src/hiposfer/kamal/directions.clj
@@ -126,7 +126,8 @@
   WARNING: we dont support multiple waypoints yet !!"
   [network steps rtrail]
   (let [trail  (rseq (into [] rtrail))
-        leg    (route-leg network steps trail)]
+        leg    (route-leg network steps trail)
+        trail  (if (= (count trail) 1) (repeat 2 (first trail)) trail)]
     {:geometry    (linestring network (map key trail))
      :duration    (:duration leg)
      :distance    (:distance leg)


### PR DESCRIPTION

```
java.lang.IllegalArgumentException: No implementation of method: :way of protocol: #'hiposfer.kamal.graph.protocols/Passage found for class: nil
	at clojure.core$_cache_protocol_fn.invokeStatic(core_deftype.clj:583)
	at clojure.core$_cache_protocol_fn.invoke(core_deftype.clj:575)
	at hiposfer.kamal.graph.protocols$fn__12959$G__12954__12964.invoke(protocols.clj:31)
	at clojure.core$map$fn__5402$fn__5403.invoke(core.clj:2722)
	at clojure.core$map$fn__5402$fn__5403.doInvoke(core.clj:2724)
	at clojure.lang.RestFn.applyTo(RestFn.java:142)
	at clojure.lang.TransformerIterator.step(TransformerIterator.java:77)
	at clojure.lang.TransformerIterator.hasNext(TransformerIterator.java:97)
	at clojure.lang.RT.chunkIteratorSeq(RT.java:507)
	at clojure.core$sequence.invokeStatic(core.clj:2646)
	at clojure.core$sequence.doInvoke(core.clj:2627)
	at clojure.lang.RestFn.invoke(RestFn.java:442)
	at hiposfer.kamal.directions$route_leg.invokeStatic(directions.clj:109)
	at hiposfer.kamal.directions$route_leg.invoke(directions.clj:104)
	at hiposfer.kamal.directions$route.invokeStatic(directions.clj:130)
	at hiposfer.kamal.directions$route.invoke(directions.clj:121)
	at hiposfer.kamal.directions$direction.invokeStatic(directions.clj:160)
	at hiposfer.kamal.directions$direction.doInvoke(directions.clj:142)
	at clojure.lang.RestFn.invoke(RestFn.java:943)
	at hiposfer.kamal.server$create$fn__14400.invoke(server.clj:54)
	at compojure.core$wrap_response$fn__2681.invoke(core.clj:158)
	at compojure.core$pre_init$fn__2732.invoke(core.clj:328)
	at compojure.api.coercion$wrap_coerce_response$fn__6722.invoke(coercion.clj:92)
	at compojure.api.middleware$wrap_coercion$fn__10407.invoke(middleware.clj:112)
	at compojure.core$pre_init$fn__2734$fn__2737.invoke(core.clj:335)
	at compojure.core$wrap_route_middleware$fn__2665.invoke(core.clj:127)
	at compojure.core$wrap_route_info$fn__2670.invoke(core.clj:137)
	at compojure.core$wrap_route_matches$fn__2674.invoke(core.clj:146)
	at compojure.core$wrap_routes$fn__2744.invoke(core.clj:348)
	at compojure.api.routes.Route.invoke(routes.clj:85)
	at compojure.core$routing$fn__2689.invoke(core.clj:185)
	at clojure.core$some.invokeStatic(core.clj:2681)
	at clojure.core$some.invoke(core.clj:2672)
	at compojure.core$routing.invokeStatic(core.clj:185)
	at compojure.core$routing.doInvoke(core.clj:182)
	at clojure.lang.RestFn.applyTo(RestFn.java:139)
	at clojure.core$apply.invokeStatic(core.clj:659)
	at clojure.core$apply.invoke(core.clj:652)
	at compojure.core$routes$fn__2693.invoke(core.clj:192)
	at compojure.api.routes.Route.invoke(routes.clj:85)
	at ring.swagger.middleware$wrap_swagger_data$fn__10334.invoke(middleware.clj:35)
	at ring.middleware.http_response$wrap_http_response$fn__6737.invoke(http_response.clj:19)
	at compojure.api.middleware$wrap_swagger_data$fn__10423.invoke(middleware.clj:175)
	at compojure.api.middleware$wrap_inject_data$fn__10404.invoke(middleware.clj:101)
	at muuntaja.middleware$wrap_params$fn__8198.invoke(middleware.clj:51)
	at compojure.api.middleware$wrap_exceptions$fn__10393.invoke(middleware.clj:67)
	at muuntaja.middleware$wrap_format_request$fn__8210.invoke(middleware.clj:113)
	at compojure.api.middleware$wrap_exceptions$fn__10393.invoke(middleware.clj:67)
	at muuntaja.middleware$wrap_format_response$fn__8214.invoke(middleware.clj:131)
	at muuntaja.middleware$wrap_format_negotiate$fn__8207.invoke(middleware.clj:95)
	at ring.middleware.keyword_params$wrap_keyword_params$fn__6771.invoke(keyword_params.clj:36)
	at ring.middleware.nested_params$wrap_nested_params$fn__6821.invoke(nested_params.clj:89)
	at ring.middleware.params$wrap_params$fn__6869.invoke(params.clj:67)
	at compojure.api.middleware$wrap_inject_data$fn__10404.invoke(middleware.clj:101)
	at compojure.api.routes.Route.invoke(routes.clj:85)
	at ring.adapter.jetty$proxy_handler$fn__452.invoke(jetty.clj:25)
	at ring.adapter.jetty.proxy$org.eclipse.jetty.server.handler.AbstractHandler$ff19274a.handle(Unknown Source)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:499)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:311)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:258)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:748)
```