### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN lein uberjar
 # second stage -- executable
 FROM openjdk:alpine
 WORKDIR /usr/src/app
-COPY --from=builder /app/target/ ./target
+COPY --from=builder /app/target/kamal.jar ./target/kamal.jar
 COPY --from=builder /app/resources/ ./resources
 EXPOSE 3000
 CMD ["java", "-Xmx500m", "-Xss512k", "-jar", "target/kamal.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
-FROM clojure
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-COPY project.clj /usr/src/app/
+# first build stage -- will be discarded
+FROM clojure AS builder
+WORKDIR /app
+COPY ./project.clj ./
 RUN lein deps
-COPY . /usr/src/app
+COPY . .
 RUN lein uberjar
+
+# second stage -- executable
+FROM openjdk:alpine
+WORKDIR /usr/src/app
+COPY --from=builder /app/target/ ./target
+COPY --from=builder /app/resources/ ./resources
 EXPOSE 3000
 CMD ["java", "-Xmx500m", "-Xss512k", "-jar", "target/kamal.jar"]

--- a/project.clj
+++ b/project.clj
@@ -38,14 +38,10 @@
   ;;FIXME: https://github.com/technomancy/leiningen/issues/2173
   :monkeypatch-clojure-test false
   :jvm-opts ["-Xmx1g" "-XX:-OmitStackTraceInFastThrow"]
-  :repositories [["snapshots" {:url "https://clojars.org/repo"
-                               :username :env/clojars_username
-                               :password :env/clojars_password}]
-                 ["releases"  {:url      "https://clojars.org/repo"
+  :repositories [["releases"  {:url      "https://clojars.org/repo"
                                :username :env/clojars_username
                                :password :env/clojars_password
                                :sign-releases false}]]
-  :deploy-repositories [["snapshots" :snapshots]
-                        ["releases"  :releases]])
+  :deploy-repositories [["releases"  :releases]])
   ;; "-Dclojure.compiler.direct-linking=true"
   ;; https://github.com/clojure/clojure/blob/master/changes.md#11-direct-linking


### PR DESCRIPTION
fixes #113 

- uses multi-stage build process
- java:alpine for efficiency
- copies only compiled jar not source code

This reduces the image from `863MB` to `149MB` :)