### PR TITLE
replaced entity id by entity itself

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [org.apache.commons/commons-compress "1.4"] ;;bz2 files read
                  [org.teneighty/java-heaps "1.0.0"]
                  [org.clojure/data.csv "0.1.4"]
-                 [datascript "0.16.3"]
+                 [datascript "0.16.4"]
                  [ch.hsr/geohash "1.3.0"]]
   :profiles {:dev {:dependencies [[criterium "0.4.4"]  ;; benchmark
                                   [expound "0.4.0"]

--- a/src/hiposfer/kamal/libs/tool.clj
+++ b/src/hiposfer/kamal/libs/tool.clj
@@ -54,10 +54,10 @@
    Only valid for OSM nodes. Assumes bidirectional links i.e. nodes with
    back-references to it are also returned"
   [network entity]
-  (map #(data/entity network %)
-       (concat (map :db/id (:node/successors entity))
-               (map :e (take-while #(= (:v %) (:db/id entity))
-                         (data/index-range network :node/successors (:db/id entity) nil))))))
+  (concat (:node/successors entity)
+          (map #(data/entity network %)
+            (map :e (take-while #(= (:v %) (:db/id entity))
+                      (data/index-range network :node/successors (:db/id entity) nil))))))
 
 (defn nearest-location
   "returns the nearest node/location datom to point"

--- a/src/hiposfer/kamal/libs/tool.clj
+++ b/src/hiposfer/kamal/libs/tool.clj
@@ -50,15 +50,16 @@
           coll))
 
 (defn node-successors
-  "takes a network and an entity id and returns the successors of that entity.
+  "takes a network and an entity and returns the successors of that entity.
    Only valid for OSM nodes. Assumes bidirectional links i.e. nodes with
-   back-references to id are also returned"
-  [network id]
-  (concat (map :db/id (:node/successors (data/entity network id)))
-          (map :e (take-while #(= (:v %) id)
-                              (data/index-range network :node/successors id nil)))))
+   back-references to it are also returned"
+  [network entity]
+  (map #(data/entity network %)
+       (concat (map :db/id (:node/successors entity))
+               (map :e (take-while #(= (:v %) (:db/id entity))
+                         (data/index-range network :node/successors (:db/id entity) nil))))))
 
-(defn nearest-node
+(defn nearest-location
   "returns the nearest node/location datom to point"
   [network point]
   (first (data/index-range network :node/location point nil)))

--- a/src/hiposfer/kamal/network/algorithms/core.clj
+++ b/src/hiposfer/kamal/network/algorithms/core.clj
@@ -54,11 +54,10 @@
   (if (= (count (nodes network)) (count settled)) (list)
     (let [start     (some #(and (not (settled %)) %)
                            (nodes network))
-          connected (breath-first network tool/node-successors start)]
+          djks (breath-first network tool/node-successors start)
+          connected (sequence (comp (map first) (map key)) djks)]
      (cons connected
-           (lazy-seq (components network (into settled
-                                               (comp (map first) (map key))
-                                               connected)))))))
+           (lazy-seq (components network (into settled connected)))))))
 
 ;; note for specs: the looner of the looner should be empty
 (defn looners
@@ -68,5 +67,5 @@
   NOTE: only relevant for pedestrian routing"
   [network]
   (let [subsets   (components network #{})
-        connected (apply max-key count subsets)]
+        connected (into #{} (apply max-key count subsets))]
     (remove #(contains? connected %) (nodes network))))

--- a/src/hiposfer/kamal/network/algorithms/dijkstra.clj
+++ b/src/hiposfer/kamal/network/algorithms/dijkstra.clj
@@ -36,14 +36,14 @@
   (if (empty? node-successors) nil
     (if (.containsKey settled (first node-successors))
       (recur value settled unsettled entry queue trail (rest node-successors))
-      (let [id      (first node-successors)
-            prev-id (key (.getValue entry))
-            weight  (np/sum (value id trail)
+      (let [entity  (first node-successors)
+            prev    (key (.getValue entry))
+            weight  (np/sum (value entity trail)
                             (.getKey entry))
-            trace2  (trace id prev-id)
-            old-entry ^Heap$Entry (.get unsettled id)]
+            trace2  (trace entity prev)
+            old-entry ^Heap$Entry (.get unsettled entity)]
         (if (nil? old-entry)
-          (.put unsettled id (.insert queue weight trace2))
+          (.put unsettled entity (.insert queue weight trace2))
           (when (< weight (.getKey old-entry))
             (.setValue old-entry trace2)
             (.decreaseKey queue old-entry weight)))
@@ -56,12 +56,12 @@
    node"
   [graph value successors ^Heap queue ^Map settled ^Map unsettled]
   (let [entry  (.extractMinimum queue)
-        id     (key (.getValue entry))
-        _      (.put settled id entry)
-        _      (.remove unsettled id)
-        trail  (path settled id)]
+        entity (key (.getValue entry))
+        _      (.put settled entity entry)
+        _      (.remove unsettled entity)
+        trail  (path settled entity)]
     (relax! value settled unsettled entry queue
-            trail (successors graph id))
+            trail (successors graph entity))
     trail))
 
 ; inspired by http://insideclojure.org/2015/01/18/reducible-generators/

--- a/src/hiposfer/kamal/services/routing/core.clj
+++ b/src/hiposfer/kamal/services/routing/core.clj
@@ -58,7 +58,7 @@
                       (time (gtfs/datomize (:gtfs area))))
         pedestrian  (if (true? dev)
                       (let [graph (gen/generate (ng/graph (:size area)))]
-                        (concat graph (ng/ways (alg/node-ids graph))))
+                        (concat graph (ng/ways (alg/nodes graph))))
                       (time (osm/datomize (:osm area))))
         conn  (data/create-conn schema)]
     (time (data/transact! conn (concat pedestrian vehicle)))

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -148,8 +148,8 @@
         traversal  (alg/dijkstra network
                                  #(duration network %1 %2)
                                  tool/node-successors
-                                 #{(:e start)})
-        rtrail     (alg/shortest-path (:e dst) traversal)]
+                                 #{(data/entity network (:e start))})
+        rtrail     (alg/shortest-path (data/entity network (:e dst)) traversal)]
     (if (some? rtrail)
       {:code "Ok"
        :routes [(route network steps rtrail)]

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -21,11 +21,6 @@
 
 (def ->coordinates (juxt np/lon np/lat))
 
-(defn location
-  "given an entity id returns its geo location assuming it is a node"
-  [network id]
-  (:node/location (data/entity network id)))
-
 (defn- link
   "find the first link that connects src and dst and returns its entity id"
   [network src-trace dst-trace]
@@ -35,18 +30,18 @@
 (defn duration
   "A very simple value computation function for arcs in a network.
   Returns the time it takes to go from src to dst based on walking speeds"
-  [network next-id trail] ;; 1 is a simple value used for test whenever no other value would be suitable
-  (let [src    (location network (key (first trail)))
-        dst    (location network next-id)
+  [network next-entity trail] ;; 1 is a simple value used for test whenever no other value would be suitable
+  (let [src    (:node/location (key (first trail)))
+        dst    (:node/location next-entity)
         length (geometry/haversine src dst)]
     (/ length osm/walking-speed)))
 
 (defn- linestring
   "get a geojson linestring based on the route path"
-  [network ids]
-  (let [coordinates (sequence (comp (map #(location network %))
+  [network entities]
+  (let [coordinates (sequence (comp (map :node/location)
                                     (map ->coordinates))
-                              ids)]
+                              entities)]
     {:type "LineString"
      :coordinates coordinates}))
 
@@ -54,11 +49,11 @@
 (defn- maneuver
   "returns a step manuever"
   [network prev-piece  piece next-piece]
-  (let [position     (location network (key (ffirst piece)))
-        pre-bearing  (geometry/bearing (location network (key (ffirst prev-piece)))
-                                       (location network (key (ffirst piece))))
-        post-bearing (geometry/bearing (location network (key (ffirst piece)))
-                                       (location network (key (ffirst next-piece))))
+  (let [position     (:node/location network (key (ffirst piece)))
+        pre-bearing  (geometry/bearing (:node/location (key (ffirst prev-piece)))
+                                       (:node/location (key (ffirst piece))))
+        post-bearing (geometry/bearing (:node/location (key (ffirst piece)))
+                                       (:node/location (key (ffirst next-piece))))
         angle        (mod (+ 360 (- post-bearing pre-bearing)) 360)
         modifier     (val (last (subseq bearing-turns <= angle)))
         way-name     (:way/name (data/entity network (second (first piece))))
@@ -147,8 +142,8 @@
    (direction network :coordinates [{:lon 1 :lat 2} {:lon 3 :lat 4}]"
   [network params]
   (let [{:keys [coordinates steps]} params
-        start      (tool/nearest-node network (first coordinates)) ;; nil when lat,lon are both greater than
-        dst        (tool/nearest-node network (last coordinates)) ;; any node in the network
+        start      (tool/nearest-location network (first coordinates)) ;; nil when lat,lon are both greater than
+        dst        (tool/nearest-location network (last coordinates)) ;; any node in the network
        ; both start and dst should be found since we checked that before
         traversal  (alg/dijkstra network
                                  #(duration network %1 %2)

--- a/src/hiposfer/kamal/services/webserver/handlers.clj
+++ b/src/hiposfer/kamal/services/webserver/handlers.clj
@@ -22,7 +22,7 @@
   "returns a network whose bounding box contains all points"
   [networks points]
   (when-let [net  (first networks)]
-    (let [distances (map #(geometry/haversine % (:v (tool/nearest-node @net %)))
+    (let [distances (map #(geometry/haversine % (:v (tool/nearest-location @net %)))
                           points)]
       (if (every? #(< % max-distance) distances) @net
         (recur (rest networks) points)))))

--- a/test/hiposfer/kamal/network/benchmark.clj
+++ b/test/hiposfer/kamal/network/benchmark.clj
@@ -19,9 +19,9 @@
   (let [dt      (gen/generate (ng/graph 1000))
         network (data/create-conn router/schema)
         _       (data/transact! network dt)
-        src     (rand-nth (alg/node-ids @network))
-        dst     (rand-nth (alg/node-ids @network))]
-    (println "\n\nDIJKSTRA forward with:" (count (alg/node-ids @network)) "nodes")
+        src     (rand-nth (alg/nodes @network))
+        dst     (rand-nth (alg/nodes @network))]
+    (println "\n\nDIJKSTRA forward with:" (count (alg/nodes @network)) "nodes")
     (println "**random graph")
     (c/quick-bench
       (let [coll (alg/dijkstra @network #(directions/duration @network %1 %2)
@@ -41,9 +41,9 @@
 ;(take 10 (alg/biggest-component (:network @networker)))
 
 (test/deftest ^:benchmark dijkstra-saarland-graph
-  (let [src     (rand-nth (alg/node-ids @network))
-        dst     (rand-nth (alg/node-ids @network))]
-    (println "\n\nDIJKSTRA forward with:" (count (alg/node-ids @network)) "nodes")
+  (let [src     (rand-nth (alg/nodes @network))
+        dst     (rand-nth (alg/nodes @network))]
+    (println "\n\nDIJKSTRA forward with:" (count (alg/nodes @network)) "nodes")
     (println "saarland graph:")
     (c/quick-bench
       (let [coll (alg/dijkstra @network #(directions/duration @network %1 %2)
@@ -56,9 +56,9 @@
 ;; I think nil src then search points less than src
 (test/deftest ^:benchmark nearest-neighbour-search
   (let [src   [7.038535 49.345088]
-        point (:v (tool/nearest-node @network src))]
+        point (:v (tool/nearest-location @network src))]
     (println "\n\nsaarland graph: nearest neighbour search with random src/dst")
     (println "B+ tree with:" (count (data/datoms @network :eavt)) "nodes")
     (println "accuraccy: " (geometry/haversine src point))
-    (c/quick-bench (:v (tool/nearest-node @network src))
+    (c/quick-bench (:v (tool/nearest-location @network src))
                    :os :runtime :verbose)))

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -99,8 +99,8 @@
   (prop/for-all [graph (gen/such-that not-empty (ng/graph 10) 1000)]
     (let [network (data/create-conn router/schema)
           _ (data/transact! network graph)
-          src  (rand-nth (alg/node-ids @network))
-          dst  (rand-nth (alg/node-ids @network))
+          src  (rand-nth (alg/nodes @network))
+          dst  (rand-nth (alg/nodes @network))
           coll (alg/dijkstra @network
                              #(direction/duration @network %1 %2)
                              tool/node-successors
@@ -119,8 +119,8 @@
   (prop/for-all [graph (gen/such-that not-empty (ng/graph 10) 1000)]
     (let [network (data/create-conn router/schema)
           _ (data/transact! network graph)
-          src  (rand-nth (alg/node-ids @network))
-          dst  (rand-nth (alg/node-ids @network))
+          src  (rand-nth (alg/nodes @network))
+          dst  (rand-nth (alg/nodes @network))
           coll (alg/dijkstra @network
                              #(direction/duration @network %1 %2)
                              tool/node-successors
@@ -140,7 +140,7 @@
   (prop/for-all [graph (gen/such-that not-empty (ng/graph 10) 1000)]
     (let [network (data/create-conn router/schema)
           _ (data/transact! network graph)
-          src  (rand-nth (alg/node-ids @network))
+          src  (rand-nth (alg/nodes @network))
           coll (alg/dijkstra @network
                              #(direction/duration @network %1 %2)
                              tool/node-successors
@@ -178,7 +178,7 @@
           _ (data/transact! network graph)
           r1      (alg/looners @network)
           _ (data/transact! network (map #(vector :db.fn/retractEntity %) r1))
-          src  (rand-nth (alg/node-ids @network))
+          src  (rand-nth (alg/nodes @network))
           coll (alg/dijkstra @network
                              #(direction/duration @network %1 %2)
                              tool/node-successors


### PR DESCRIPTION
fix: avoid finding the entity over and over in the db
fix: return entities not ids in node-successors
renamed nearest-node to nearest-location for clarity

BLOCKED by: https://github.com/tonsky/datascript/pull/255
the algorithm never ends since it keeps inserting the same entities in the queue due to wrong `equals`