### PR TITLE
fix: remote zip files can only be streamed not randomly accessed

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.6.2"
+(defproject hiposfer/kamal "0.6.3"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"


### PR DESCRIPTION
My previous implementation (implicitedly) assumed that the gtfs zip file would be located on the local machine, which of course doesnt work kamal as a web server.

This PR changes that and makes the zip processing through a `ZipInputStream` taken from the http response.

It also makes it a bit slower. This is an unfortunate consequence since before we could access the specific file directly, but since now they are being streamed we need to process them all before passing them to Datascript. Datascript in turns requires the input to have a certain order to establish the relations between elements i.e. first the definitions (like node, route) and then the relations (like trip for route, stop time for trip)