### PR TITLE
Instructions

### DIFF
--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -5,11 +5,11 @@
   By convention all queries here return Entities"
   (:require [datascript.core :as data]
             [hiposfer.kamal.libs.tool :as tool])
-  (:import (java.time Duration LocalTime LocalDate LocalDateTime)))
+  (:import (java.time LocalDate)))
 
 (defn index-lookup
   "returns a transducer that can be used together with index-range to get all
-  entities attribute k equals id"
+  entities whose value equals id i.e. the entities that have a reference to id"
   [network id]
   (comp (take-while #(= (:v %) id))
         (map #(data/entity network (:e %)))))
@@ -59,6 +59,8 @@
 (defn continue-trip
   "returns the :stop.times entity to reach ?dst-id via ?trip
 
+  Returns nil if no trip going to ?dst-id was found
+
   replaces:
   '[:find ?departure
     :in $ ?dst-id ?trip ?start
@@ -69,10 +71,12 @@
 
    The previous query takes around 50 milliseconds to execute. This function
    takes around 0.22 milliseconds to execute. Depends on :stop.times/trip index"
-  [network ?dst-id ?trip]
-  (tool/some #(= ?dst-id (:db/id (:stop.times/stop %)))
-             (eduction (index-lookup network ?trip)
-                       (data/index-range network :stop.times/trip ?trip nil))))
+  [network dst trip]
+  (let [?dst-id  (:db/id dst)
+        ?trip-id (:db/id trip)]
+    (tool/some #(= ?dst-id (:db/id (:stop.times/stop %)))
+               (eduction (index-lookup network ?trip-id)
+                         (data/index-range network :stop.times/trip ?trip-id nil)))))
 
 (defn- min-departure
   [result value]
@@ -82,7 +86,9 @@
 
 (defn find-trip
   "Returns a [src dst] stop.times pair for the next trip between ?src-id
-   and ?dst-id departing after ?now
+   and ?dst-id departing after ?now.
+
+   Returns nil if no trip was found
 
   replaces:
   '[:find ?trip ?departure
@@ -96,14 +102,15 @@
            [(hiposfer.kamal.libs.fastq/after? ?departure ?now)]]
 
   The previous query runs in 118 milliseconds. This function takes 4 milliseconds"
-  [network trips ?src-id ?dst-id ?now]
-  (let [sts  (seq (eduction (comp (index-lookup network ?src-id)
-                                  (filter #(and (> (:stop.times/departure_time %) ?now)
-                                                (contains? trips (:db/id (:stop.times/trip %))))))
-                            (data/index-range network :stop.times/stop ?src-id nil)))]
+  [network trips src dst now]
+  (let [?src-id (:db/id src)
+        sts  (eduction (comp (index-lookup network ?src-id)
+                             (filter #(and (> (:stop.times/departure_time %) now)
+                                           (contains? trips (:db/id (:stop.times/trip %))))))
+                       (data/index-range network :stop.times/stop ?src-id nil))]
     (when (seq sts)
-      (let [trip (reduce min-departure sts)]
-        [trip (continue-trip network ?dst-id (:db/id (:stop.times/trip trip)))]))))
+      (let [trip (reduce min-departure (first sts) sts)]
+        [trip (continue-trip network dst (:stop.times/trip trip))]))))
 
 ;(time
 ;  (dotimes [n 1000]
@@ -129,8 +136,19 @@
                     (map :e))
               (data/seek-datoms network :avet :trip/service))))
 
+(defn- index-ref
+  "returns all entities that reference entity through attribute k"
+  ([network k entity]
+   (index-ref network k entity (map identity)))
+  ([network k entity xform]
+   (eduction (comp (index-lookup network (:db/id entity))
+                   xform)
+             (data/index-range network k (:db/id entity) nil))))
+
 (defn next-stops
   "return the next stop entities for ?src-id based on stop.times
+
+  This function might return duplicates
 
   replaces:
   '[:find [?id ...]
@@ -144,18 +162,15 @@
            [?dst :stop.times/stop ?se]
            [?se :stop/id ?id]]
   the previous query takes 145 milliseconds. This function takes 0.2 milliseconds"
-  [network ?src]
-  (let [id         (:db/id ?src)
-        stop-times (sequence (index-lookup network id)
-                             (data/index-range network :stop.times/stop id nil))
-        stops      (for [st1  stop-times
-                         :let [trip-id (:db/id (:stop.times/trip st1))
-                               stimes2 (sequence (index-lookup network trip-id)
-                                                 (data/index-range network :stop.times/trip trip-id nil))]
-                         st2  stimes2
-                         :when (> (:stop.times/sequence st2) (:stop.times/sequence st1))]
-                     (:stop.times/stop st2))]
-    (distinct stops)))
+  [network src]
+  (for [st1  (index-ref network :stop.times/stop src)
+        :let [stimes2 (index-ref network
+                                 :stop.times/trip
+                                 (:stop.times/trip st1)
+                                 (filter #(> (:stop.times/sequence %)
+                                             (:stop.times/sequence st1))))]
+        :when (not-empty stimes2)]
+      (:stop.times/stop (apply min-key :stop.times/sequence stimes2))))
 
 ;(time
 ;  (dotimes [n 10000]

--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -136,10 +136,10 @@
                     (map :e))
               (data/seek-datoms network :avet :trip/service))))
 
-(defn- index-ref
+(defn- references
   "returns all entities that reference entity through attribute k"
   ([network k entity]
-   (index-ref network k entity (map identity)))
+   (references network k entity (map identity)))
   ([network k entity xform]
    (eduction (comp (index-lookup network (:db/id entity))
                    xform)
@@ -163,12 +163,12 @@
            [?se :stop/id ?id]]
   the previous query takes 145 milliseconds. This function takes 0.2 milliseconds"
   [network src]
-  (for [st1  (index-ref network :stop.times/stop src)
-        :let [stimes2 (index-ref network
-                                 :stop.times/trip
-                                 (:stop.times/trip st1)
-                                 (filter #(> (:stop.times/sequence %)
-                                             (:stop.times/sequence st1))))]
+  (for [st1  (references network :stop.times/stop src)
+        :let [stimes2 (references network
+                                  :stop.times/trip
+                                  (:stop.times/trip st1)
+                                  (filter #(> (:stop.times/sequence %)
+                                              (:stop.times/sequence st1))))]
         :when (not-empty stimes2)]
       (:stop.times/stop (apply min-key :stop.times/sequence stimes2))))
 

--- a/src/hiposfer/kamal/parsers/gtfs/core.clj
+++ b/src/hiposfer/kamal/parsers/gtfs/core.clj
@@ -52,17 +52,17 @@
               "stop_times.txt" :stop.times})
 
 (def preparer
-  "map of GTFS namespaces post-processing functions. Useful to remove unnecessary
-   information from the GTFS feed. Just to reduce the amount of datoms in
-   datascript"
-  {:calendar service
-   :routes   #(dissoc % :route_url)
-   :trips    #(dissoc % :shape_id)
-   :stops    (fn [stop]
-               (let [removable [:stop_lat :stop_lon]
-                     ks (apply disj (set (keys stop)) removable)
-                     loc (network/->Location (:stop_lon stop) (:stop_lat stop))]
-                 (assoc (select-keys stop ks) :stop_location loc)))})
+  "map of GTFS filenames to post-processing functions. Useful to remove
+   unnecessary information from the GTFS feed; just to reduce the amount
+    of datoms in datascript"
+  {"calendar.txt" service
+   "routes.txt"   #(dissoc % :route_url)
+   "trips.txt"    #(dissoc % :shape_id)
+   "stops.txt"    (fn [stop]
+                    (let [removable [:stop_lat :stop_lon]
+                          ks (apply disj (set (keys stop)) removable)
+                          loc (network/->Location (:stop_lon stop) (:stop_lat stop))]
+                      (assoc (select-keys stop ks) :stop_location loc)))})
 
 (defn respace
   "takes a keyword and a set of keywords and attempts to convert it into a
@@ -92,7 +92,7 @@
       :else [(keyword sbase (name nk)) v])))
 
 ;; TODO: we can process files this way because Clojure array-maps
-;; maintain the order of the elements. However this is only valid for
+;; maintains the order of the elements. However this is only valid for
 ;; up to 8 key-value pairs. Once we start processing more, we would need
 ;; to change the logic
 (defn datomize!
@@ -112,7 +112,7 @@
       :else
       (let [filename (.getName entry)
             ns-base  (get file-ns filename)
-            prepare  (get preparer ns-base)
+            prepare  (get preparer filename)
             content  (pregtfs/parse! zipstream filename prepare)
             ;; transform each entry into a valid datascript
             ;; transaction map

--- a/src/hiposfer/kamal/services/routing/core.clj
+++ b/src/hiposfer/kamal/services/routing/core.clj
@@ -66,7 +66,7 @@
                    (data/datoms network :aevt :stop/id))]
     (let [node (first (fastq/nearest-node network (:stop/location stop)))]
       {:node/id (:node/id node)
-       :node/successors #{(:db/id stop)}})))
+       :node/successors #{[:stop/id (:stop/id stop)]}})))
 
 ;; this reduced my test query from 30 seconds to 8 seconds
 (defn- cache-stop-successors
@@ -75,9 +75,9 @@
   [network]
   (for [stop (map #(data/entity network (:e %))
                    (data/datoms network :aevt :stop/id))]
-    (let [neighbours (fastq/next-stops network stop)]
+    (let [neighbours (distinct (fastq/next-stops network stop))]
       {:stop/id (:stop/id stop)
-       :stop/successors (map :db/id neighbours)})))
+       :stop/successors (for [n neighbours] [:stop/id (:stop/id n)])})))
 
 (defn- exec!
   "builds a datascript in-memory db and conj's it into the passed agent"

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -39,7 +39,7 @@
       (first (fastq/node-ways network src))
       ;; on a trip
       (and (transit/stop? src) (transit/stop? dst))
-      (:source (val src-trace)) ;; TripStep
+      (:start (val src-trace)) ;; TripStep
       ;; leaving a trip
       (and (transit/stop? src) (transit/node? dst))
       (first (fastq/node-ways network src)))))
@@ -150,7 +150,8 @@
           traces&ways (map vector trail (concat vias [(last vias)]))
           pieces      (partition-by #(transit/name (second %)) traces&ways)]
       {:distance   (geometry/arc-length (:coordinates (linestring (map key trail))))
-       :duration   (np/cost (val (last trail)))
+       :duration   (- (np/cost (val (last trail)))
+                      (np/cost (val (first trail))))
        :steps      (route-steps steps pieces)
        :summary    "" ;; TODO
        :annotation []}))) ;; TODO

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -109,8 +109,9 @@
         result       {:location (->coordinates position)
                       :bearing_before pre-bearing
                       :bearing_after  post-bearing
-                      :type _type
-                      :modifier _modifier}]
+                      :type _type}
+        result        (if (not= _type "turn") result
+                        (assoc result :modifier _modifier))]
     (assoc result :instruction
                   (instruction result (second (first piece))))))
 

--- a/src/hiposfer/kamal/services/routing/transit.clj
+++ b/src/hiposfer/kamal/services/routing/transit.clj
@@ -1,10 +1,10 @@
 (ns hiposfer.kamal.services.routing.transit
+  (:refer-clojure :exclude [name])
   (:require [hiposfer.kamal.network.algorithms.protocols :as np]
             [hiposfer.kamal.libs.fastq :as fastq]
             [hiposfer.kamal.parsers.osm :as osm]
             [hiposfer.kamal.libs.geometry :as geometry]
-            [datascript.core :as data])
-  (:import (java.time LocalDate)))
+            [datascript.core :as data]))
 
 ;; https://developers.google.com/transit/gtfs/reference/#routestxt
 (def route-types
@@ -51,8 +51,16 @@
 (defn node? [e] (:node/id e))
 (defn way? [e] (:way/id e))
 (defn stop? [e] (:stop/id e))
-(defn stop.times? [e] (:stop.times/trip e))
+(defn stop-times? [e] (:stop.times/trip e))
 (defn trip-step? [o] (instance? TripStep o))
+
+(defn name
+  "returns a name that represents this entity in the network.
+   returns nil if the entity has no name"
+  [e]
+  (cond
+    (way? e) (:way/name e)
+    (stop-times? e) (:trip/headsign (:stop.times/trip e))))
 
 (defn successors
   "takes a network and an entity id and returns the successors of that entity"

--- a/src/hiposfer/kamal/services/webserver/handlers.clj
+++ b/src/hiposfer/kamal/services/webserver/handlers.clj
@@ -6,9 +6,7 @@
             [hiposfer.kamal.services.routing.directions :as dir]
             [hiposfer.kamal.libs.geometry :as geometry]
             [hiposfer.kamal.libs.fastq :as fastq]
-            [hiposfer.kamal.services.routing.transit :as transit]
-            [datascript.core :as data]
-            [taoensso.timbre :as timbre])
+            [datascript.core :as data])
   (:import (java.time LocalDateTime)))
 
 (defn- validate
@@ -58,24 +56,12 @@
       (route/not-found (code/not-found "we couldnt find what you were looking for")))))
 
 ;; TESTS
-;{"arguments":
-; {"coordinates": [[6.905707,49.398459],
-;                  [6.8992, 49.4509]]}}
-
 ;(fastq/nearest-node @(first @(:networks (:router hiposfer.kamal.dev/system)))
 ;                    [6.905707,49.398459])
 
 ;(time
-;  (dotimes [n 20]
-;    (dir/direction @(first @(:networks (:router hiposfer.kamal.dev/system)))
-;                   {;:steps       true
-;                    :coordinates [[6.905707, 49.398459]
-;                                  [6.8992, 49.4509]]
-;                    :departure   (LocalDateTime/now)})))
-;
-;(time
 ;  (dir/direction @(first @(:networks (:router hiposfer.kamal.dev/system)))
-;                 {;:steps       true
-;                  :coordinates [[6.905707, 49.398459]
-;                                [6.8992, 49.4509]]
-;                  :departure   (LocalDateTime/now)}))
+;                 {:coordinates [[8.645333, 50.087314]
+;                                [8.635897, 50.104172]]
+;                               :departure (LocalDateTime/parse "2018-05-07T10:15:30")
+;                  :steps true}))


### PR DESCRIPTION
There are several changes in this PR. All related to each other but slightly different scope. In general, this PR attempts to fix #156 . However since we still dont have proper GTFS data integrated, the routing always shows pedestrian routing.

I am currently assuming that once we get a gtfs feed without the timing problem then we will see the public transport instructions in the directions endpoint.

- cosmetic changes -> documentation and small code refactoring for readability
- made a mini-convention to use `?var-name` whenever it is meant a Datascript entity id. Just to be able to quickly inspect the code
- fix: eduction doesnt support reduce without init value
- fix: next-stops function was returning all stops of a route, not just the next one
- fix: preparer was using old keywords which were not matching the current ones, therefore those functions were never triggered
- fix: the duration of a route was shown as the last value instead of `last - first`
- simplified the logic of route-steps to avoid special cases and just handle everything in a standard way. Just to avoid brain-twisting logic