### PR TITLE
Steps info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
 # test requires quite some memory so free it afterwards
 - lein trampoline test
 # linter
-- lein eastwood '{:exclude-namespaces [hiposfer.kamal.network.specs hiposfer.kamal.specs.mapbox.directions hiposfer.kamal.network.graph.specs]}'
+- lein eastwood
 notifications:
   email:
     on_success: change

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.8.3"
+(defproject hiposfer/kamal "0.9.0"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"
@@ -13,18 +13,19 @@
                  [com.taoensso/timbre "4.10.0"]
                  [ring/ring-jetty-adapter "1.6.3"]
                  [com.stuartsierra/component "0.3.2"]
-                 [org.apache.commons/commons-compress "1.16.1"] ;;bz2 files read
+                 [org.apache.commons/commons-compress "1.17"] ;;bz2 files read
                  [org.teneighty/java-heaps "1.0.0"]
                  [org.clojure/data.csv "0.1.4"]
-                 [datascript "0.16.5"]
+                 [datascript "0.16.6"]
                  [ch.hsr/geohash "1.3.0"]]
   :aliases {"preprocess" ["trampoline" "run" "-m" "hiposfer.kamal.preprocessor"]}
   :profiles {:dev {:dependencies [[criterium "0.4.4"]  ;; benchmark
-                                  [expound "0.6.0"]
+                                  [expound "0.7.0"]
                                   [io.aviso/pretty "0.1.34"]
                                   [org.clojure/tools.namespace "0.2.11"]]
-                   :plugins [[jonase/eastwood "0.2.5"]
-                             [io.aviso/pretty "0.1.34"]]}
+                   :plugins [[jonase/eastwood "0.2.6"]
+                             [io.aviso/pretty "0.1.34"]]
+                   :eastwood {:config-files ["resources/eastwood.clj"]}}
              :release {:aot [hiposfer.kamal.core] ;; compile the entry point and all of its dependencies}
                        :main hiposfer.kamal.core
                        :uberjar-name "kamal.jar"
@@ -33,15 +34,10 @@
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}}
   :test-selectors {:default (complement :benchmark)
                    :benchmark :benchmark}
-  :global-vars {*warn-on-reflection* true
-                *print-length* 100}
   ;;FIXME: https://github.com/technomancy/leiningen/issues/2173
   :monkeypatch-clojure-test false
-  :jvm-opts ["-Xmx1g" "-XX:-OmitStackTraceInFastThrow"]
   :repositories [["releases"  {:url      "https://clojars.org/repo"
                                :username :env/clojars_username
                                :password :env/clojars_password
                                :sign-releases false}]]
   :deploy-repositories [["releases"  :releases]])
-  ;; "-Dclojure.compiler.direct-linking=true"
-  ;; https://github.com/clojure/clojure/blob/master/changes.md#11-direct-linking

--- a/resources/eastwood.clj
+++ b/resources/eastwood.clj
@@ -1,0 +1,16 @@
+;; linter config
+
+(disable-warning
+  {:linter :constant-test
+   :if-inside-macroexpansion-of #{'clojure.core/as->}
+   :within-depth 2
+   :reason "Allow as-> to have constant tests without warning"})
+
+(disable-warning
+  {:linter :constant-test
+   :if-inside-macroexpansion-of #{'clojure.spec/every 'clojure.spec.alpha/every
+                                  'clojure.spec/and 'clojure.spec.alpha/and
+                                  'clojure.spec/keys 'clojure.spec.alpha/keys
+                                  'clojure.spec/coll-of 'clojure.spec.alpha/coll-of}
+   :within-depth 6
+   :reason "clojure.spec's macros `keys`, `every`, and `and` often contain `clojure.core/and` invocations with only one argument."})

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -54,6 +54,8 @@
   (clojure.spec.test.alpha/instrument)
   (set! s/*explain-out* (expound/custom-printer {:theme :figwheel-theme
                                                  :print-specs? false}))
+  (set! *warn-on-reflection* true)
+  (set! *print-length* 100)
   (start!))
 
 (defn refresh!

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -144,7 +144,7 @@
       (= _type "turn")      (assoc :modifier (modifier angle _type))
       (= "notification" _type) (assoc :wait (wait-time piece next-piece))
       (= "notification" _type) (assoc :trip (:trip/id (:stop.times/trip (:start (val (first next-piece))))))
-      :always (as-> $ (assoc $ :instruction (instruction network $ piece next-piece))))))
+      :else (as-> $ (assoc $ :instruction (instruction network $ piece next-piece))))))
 
 ;https://www.mapbox.com/api-documentation/#routestep-object
 (defn- step ;; piece => [trace ...]

--- a/src/hiposfer/kamal/specs/mapbox/directions.clj
+++ b/src/hiposfer/kamal/specs/mapbox/directions.clj
@@ -6,13 +6,21 @@
             [hiposfer.kamal.services.routing.directions :as dir])
   (:import (java.time LocalDateTime)))
 
-(defn- consistent?
+;; TODO: these functions look ugly as hell. I dont think we are modelling it
+;; the right way but it gets the job done for the time being.
+(defn- consistent-maneuver?
   [step]
   (case (:mode step)
     "transit" (contains? #{"notification" "continue" "exit vehicle"}
                          (:type (:maneuver step)))
     "walking" (contains? #{"depart" "arrive" "turn"}
                          (:type (:maneuver step)))))
+
+(defn- vehicle-info?
+  [man]
+  (if (not= "notification" (:type man)) true
+    (and (s/valid? ::wait (:wait man))
+         (s/valid? ::trip (:trip man)))))
 
 (defn- natural? [n] (>= n 0))
 
@@ -26,21 +34,25 @@
 (s/def ::mode        #{"walking" "transit"})
 (s/def ::instruction (s/and string? not-empty))
 (s/def ::modifier    (set (vals dir/bearing-turns)))
+(s/def ::positive    (s/and spec/number? natural?))
+(s/def ::wait        ::positive)
+(s/def ::trip        double?)
 (s/def ::bearing     (s/and spec/number? #(<= 0 % 360)))
 (s/def ::bearing_before ::bearing)
 (s/def ::bearing_after  ::bearing)
 (s/def ::location    ::geojson/position)
-(s/def ::duration    (s/and spec/number? natural?))
-(s/def ::distance    (s/and spec/number? natural?))
-(s/def ::weight      (s/and spec/number? natural?)) ;; a negative weight doesnt make sense
+(s/def ::duration    ::positive)
+(s/def ::distance    ::positive)
+(s/def ::weight      ::positive)
 (s/def ::weight_name string?)
 ;; structures
-(s/def ::maneuver    (s/keys :req-un [::location ::bearing_before ::bearing_after
-                                      ::instruction ::type]
-                             :opt-un [::modifier]))
+(s/def ::maneuver    (s/and (s/keys :req-un [::location ::bearing_before ::bearing_after
+                                             ::instruction ::type]
+                                    :opt-un [::modifier])
+                            vehicle-info?))
 (s/def ::route-step  (s/and (s/keys :req-un [::distance ::duration ::geometry
                                              ::name     ::mode     ::maneuver])
-                            consistent?))
+                            consistent-maneuver?))
 (s/def ::steps       (s/coll-of ::route-step :kind sequential?))
 (s/def ::route-leg   (s/keys :req-un [::distance ::duration ::steps ::summary]))
 (s/def ::legs        (s/coll-of ::route-leg :kind sequential?))

--- a/src/hiposfer/kamal/specs/mapbox/directions.clj
+++ b/src/hiposfer/kamal/specs/mapbox/directions.clj
@@ -4,7 +4,7 @@
             [hiposfer.geojson.specs :as geojson]
             [clojure.spec.gen.alpha :as gen]
             [hiposfer.kamal.services.routing.directions :as dir])
-  (:import (java.time LocalDateTime)))
+  (:import (java.time LocalDateTime ZoneOffset)))
 
 ;; TODO: these functions look ugly as hell. I dont think we are modelling it
 ;; the right way but it gets the job done for the time being.
@@ -71,7 +71,7 @@
 
 ;; 2017 -> 1483228800
 (defn localdatetime-gen []
-  (gen/fmap #(java.time.LocalDateTime/ofEpochSecond % 0 java.time.ZoneOffset/UTC)
+  (gen/fmap #(LocalDateTime/ofEpochSecond % 0 ZoneOffset/UTC)
             (gen/large-integer* {:min 1483228800 :max 365241780471})))
 
 (s/def ::departure


### PR DESCRIPTION
- fixes #184 -> not necessary since we include the :wait keyword which can be used to calculate the next departure
- fixes #183 
- fixes #182 

changes eastwood config to disable spec warning according to https://github.com/jonase/eastwood/issues/227