### PR TITLE
Edn data

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.10.0"
+(defproject hiposfer/kamal "0.11.0"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"
@@ -24,10 +24,8 @@
   :aliases {"preprocess" ["trampoline" "run" "-m" "hiposfer.kamal.preprocessor"]}
   :profiles {:dev {:dependencies [[criterium "0.4.4"]  ;; benchmark
                                   [expound "0.7.0"]
-                                  [io.aviso/pretty "0.1.34"]
                                   [org.clojure/tools.namespace "0.2.11"]]
-                   :plugins [[jonase/eastwood "0.2.6"]
-                             [io.aviso/pretty "0.1.34"]]
+                   :plugins [[jonase/eastwood "0.2.6"]]
                    :eastwood {:config-files ["resources/eastwood.clj"]}}
              :release {:aot [hiposfer.kamal.core] ;; compile the entry point and all of its dependencies}
                        :main hiposfer.kamal.core

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -18,7 +18,7 @@
             [hiposfer.kamal.libs.fastq :as fastq]
             [datascript.core :as data]
             [hiposfer.kamal.libs.tool :as tool])
-  (:import (java.time LocalDateTime Duration LocalTime)))
+  (:import (java.time LocalDateTime Duration LocalTime LocalDate)))
 
 ;; https://www.mapbox.com/api-documentation/#stepmaneuver-object
 (def bearing-turns
@@ -55,8 +55,8 @@
   "returns a human readable version of the maneuver to perform"
   [network result piece next-piece]
   (let [context  (transit/context network piece)
-        modifier (:modifier result)
-        maneuver (:type result)
+        modifier (:maneuver/modifier result)
+        maneuver (:maneuver/type result)
         name     (transit/name context)]
     (case maneuver
       ;; walking normally
@@ -130,32 +130,33 @@
                                        (location (key (first next-piece))))
         angle        (mod (+ 360 (- post-bearing pre-bearing)) 360)
         _type        (maneuver-type network prev-piece piece next-piece)
-        result       (merge {:bearing_before pre-bearing
-                             :bearing_after  post-bearing
-                             :type _type}
+        result       (merge {:maneuver/bearing_before pre-bearing
+                             :maneuver/bearing_after  post-bearing
+                             :maneuver/type _type}
                        (when (= _type "turn")
-                         {:modifier (modifier angle _type)}))]
-    (assoc result :instruction (instruction network result piece next-piece))))
+                         {:maneuver/modifier (modifier angle _type)}))]
+    (assoc result :maneuver/instruction (instruction network result piece next-piece))))
 
 ;https://www.mapbox.com/api-documentation/#routestep-object
 (defn- step ;; piece => [trace ...]
   "includes one StepManeuver object and travel to the following RouteStep"
-  [network prev-piece piece next-piece]
+  [^LocalDateTime start network prev-piece piece next-piece]
   (let [context (transit/context network piece)
         line    (linestring (map key (concat piece [(first next-piece)])))
         man     (maneuver network prev-piece piece next-piece)
-        mode    (if (transit/stop? context) "transit" "walking")]
-    (merge
-      {:mode     mode
-       :maneuver man
-       :distance (geometry/arc-length (:coordinates line))
-       :duration (- (np/cost (val (first next-piece)))
-                    (np/cost (val (first piece))))
-       :geometry line}
+        mode    (if (transit/stop? context) "transit" "walking")
+        departs (np/cost (val (first piece)))
+        arrives (np/cost (val (first next-piece)))]
+    (merge man
+      {:step/mode     mode
+       :step/distance (geometry/arc-length (:coordinates line))
+       :step/duration (Duration/ofSeconds (- arrives departs))
+       :step/geometry line}
       (when (some? (transit/name context))
-        {:name (transit/name context)})
-      (when (= "notification" (man :type))
-        {:arrival_time (np/cost (val (first piece)))})
+        {:step/name (transit/name context)})
+      (if (= "arrive" (:type man))
+        {:step/arrive (. start (plusSeconds arrives))}
+        {:step/departure (. start (plusSeconds departs))})
       (when (= "transit" mode)
         (if (= "exit vehicle" (man :type))
           (tool/gtfs-resource (:end (val (first piece))))
@@ -163,27 +164,32 @@
 
 (defn- route-steps
   "returns a route-steps vector or an empty vector if no steps are needed"
-  [network pieces] ;; piece => [[trace via] ...]
+  [network pieces midnight] ;; piece => [[trace via] ...]
   (let [start     [(first pieces)] ;; add depart and arrival pieces into the calculation
         end       (repeat 2 [(last (last pieces))]) ;; use only the last point as end - not the entire piece
         extended  (concat start pieces end)]
-    (map step (repeat network) extended (rest extended) (rest (rest extended)))))
+    (map step (repeat midnight)
+              (repeat network)
+              extended
+              (rest extended)
+              (rest (rest extended)))))
 
 ;https://www.mapbox.com/api-documentation/#route-object
 (defn- route
   "a route from the first to the last waypoint. Only two waypoints
   are currently supported"
-  [network rtrail]
+  [network rtrail midnight]
   (let [trail  (rseq (into [] rtrail))]
     (if (= (count trail) 1) ;; a single trace is returned for src = dst
-      {:distance 0 :duration 0 :steps [] :summary "" :annotation []}
+      {:route/distance 0 :route/duration 0 :route/steps []}
       (let [previous    (volatile! (first trail))
             pieces      (partition-by #(transit/name (transit/context! network % previous))
-                                       trail)]
-        {:distance   (geometry/arc-length (:coordinates (linestring (map key trail))))
-         :duration   (- (np/cost (val (last trail)))
-                        (np/cost (val (first trail))))
-         :steps      (route-steps network pieces)}))))
+                                       trail)
+            departs     (np/cost (val (last trail)))
+            arrives     (np/cost (val (first trail)))]
+        {:route/distance (geometry/arc-length (:coordinates (linestring (map key trail))))
+         :route/duration (Duration/ofSeconds (- arrives departs))
+         :route/steps    (route-steps network pieces midnight)}))))
 
 ;; for the time being we only care about the coordinates of start and end
 ;; but looking into the future it is good to make like this such that we
@@ -197,30 +203,28 @@
    Example:
    (direction network :coordinates [{:lon 1 :lat 2} {:lon 3 :lat 4}]"
   [network params]
+  (println params)
   (let [{:keys [coordinates ^LocalDateTime departure]} params
-        date       (.toLocalDate departure)
+        date       (. departure (toLocalDate))
         trips      (fastq/day-trips network date)
         start      (Duration/between (LocalTime/MIDNIGHT)
-                                     (.toLocalTime departure))
+                                     (. departure (toLocalTime)))
         src        (first (fastq/nearest-node network (first coordinates)))
         dst        (first (fastq/nearest-node network (last coordinates)))
        ; both start and dst should be found since we checked that before
-        traversal  (alg/dijkstra network #{[src (.getSeconds start)]}
+        traversal  (alg/dijkstra network #{[src (. start (getSeconds))]}
                                  {:value-by   #(transit/timetable-duration network trips %1 %2)
                                   :successors transit/successors
                                   :comparator transit/by-cost})
         rtrail     (alg/shortest-path dst traversal)]
-    (if (some? rtrail)
-      {:code      "Ok"
-       :uuid      (data/squuid)
-       :waypoints [{:name     (str (some :way/name (fastq/node-ways network src)))
-                    :location (->coordinates (:node/location src))}
-                   {:name     (str (some :way/name (fastq/node-ways network dst)))
-                    :location (->coordinates (:node/location dst))}]
-       :route     (route network rtrail)}
-      {:code "NoRoute"
-       :message "There was no route found for the given coordinates. Check for
-                       impossible routes (e.g. routes over oceans without ferry connections)."})))
+    (when (some? rtrail)
+      (merge
+        {:route/uuid      (data/squuid)
+         :route/waypoints [{:waypoint/name     (some :way/name (fastq/node-ways network src))
+                            :waypoint/location (->coordinates (location src))}
+                           {:waypoint/name     (some :way/name (fastq/node-ways network dst))
+                            :waypoint/location (->coordinates (location dst))}]}
+        (route network rtrail (. date (atStartOfDay)))))))
 
 ;(time
 ;  (direction @(first @(:networks (:router hiposfer.kamal.dev/system)))

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -185,8 +185,8 @@
       (let [previous    (volatile! (first trail))
             pieces      (partition-by #(transit/name (transit/context! network % previous))
                                        trail)
-            departs     (np/cost (val (last trail)))
-            arrives     (np/cost (val (first trail)))]
+            departs     (np/cost (val (first trail)))
+            arrives     (np/cost (val (last trail)))]
         {:route/distance (geometry/arc-length (:coordinates (linestring (map key trail))))
          :route/duration (Duration/ofSeconds (- arrives departs))
          :route/steps    (route-steps network pieces midnight)}))))
@@ -203,6 +203,7 @@
    Example:
    (direction network :coordinates [{:lon 1 :lat 2} {:lon 3 :lat 4}]"
   [network params]
+  (println params)
   (let [{:keys [coordinates ^LocalDateTime departure]} params
         date       (. departure (toLocalDate))
         trips      (fastq/day-trips network date)

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -152,7 +152,7 @@
        :step/distance (geometry/arc-length (:coordinates line))
        :step/duration (Duration/ofSeconds (- arrives departs))
        :step/geometry line}
-      (when (some? (transit/name context))
+      (when (not-empty (transit/name context))
         {:step/name (transit/name context)})
       (if (= "arrive" (:type man))
         {:step/arrive (. start (plusSeconds arrives))}
@@ -203,7 +203,6 @@
    Example:
    (direction network :coordinates [{:lon 1 :lat 2} {:lon 3 :lat 4}]"
   [network params]
-  (println params)
   (let [{:keys [coordinates ^LocalDateTime departure]} params
         date       (. departure (toLocalDate))
         trips      (fastq/day-trips network date)
@@ -220,10 +219,13 @@
     (when (some? rtrail)
       (merge
         {:route/uuid      (data/squuid)
-         :route/waypoints [{:waypoint/name     (some :way/name (fastq/node-ways network src))
-                            :waypoint/location (->coordinates (location src))}
-                           {:waypoint/name     (some :way/name (fastq/node-ways network dst))
-                            :waypoint/location (->coordinates (location dst))}]}
+         :route/waypoints
+         [{:waypoint/name     (some (comp not-empty :way/name)
+                                    (fastq/node-ways network src))
+           :waypoint/location (->coordinates (location src))}
+          {:waypoint/name     (some (comp not-empty :way/name)
+                                    (fastq/node-ways network dst))
+           :waypoint/location (->coordinates (location dst))}]}
         (route network rtrail (. date (atStartOfDay)))))))
 
 ;(time

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -178,8 +178,8 @@
     (let [graph   @(router/pedestrian-graph {:SIZE i})
           request  (gen/generate (s/gen ::dataspecs/params))
           result   (dir/direction graph request)]
-      (is (s/valid? ::dataspecs/response result)
-          (str (expound/expound-str ::dataspecs/response result))))))
+      (is (s/valid? ::dataspecs/route result)
+          (str (expound/expound-str ::dataspecs/route result))))))
 
 ; -----------------------------------------------------------------
 ; generative tests for the direction endpoint
@@ -196,7 +196,7 @@
           depart   (gen/generate (s/gen ::dataspecs/departure))
           args     {:coordinates [src dst] :departure depart :steps true}
           result   (dir/direction graph args)]
-      (is (s/valid? ::dataspecs/response result)
-          (str (expound/expound-str ::dataspecs/response result))))))
+      (is (s/valid? ::dataspecs/route result)
+          (str (expound/expound-str ::dataspecs/route result))))))
 
 ;(clojure.test/run-tests)


### PR DESCRIPTION
- fixes #196 
- fixes #197 
- gives priority to EDN representation for directions response. Namely, namespacing the keywords so that they can be used with ease in `hive`