### PR TITLE
Gtfs data

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,7 @@
   :aliases {"preprocess" ["trampoline" "run" "-m" "hiposfer.kamal.preprocessor"]}
   :profiles {:dev {:dependencies [[criterium "0.4.4"]  ;; benchmark
                                   [expound "0.7.0"]
+                                  [markdown2clj "0.1.3"]
                                   [org.clojure/tools.namespace "0.2.11"]]
                    :plugins [[jonase/eastwood "0.2.6"]]
                    :eastwood {:config-files ["resources/eastwood.clj"]}}

--- a/resources/gtfs/reference.edn
+++ b/resources/gtfs/reference.edn
@@ -134,10 +134,10 @@
      ("* 0 or blank - Stop. A location where passengers board or disembark from a transit vehicle."
       {:description
        "Station. A physical structure or area that contains one or more stop.",
-       :value "1"}
+       :value 1}
       {:description
        "Station Entrance/Exit. A location where passengers can enter or exit a station from the street. The stop entry must also specify a parent_station value referencing the stop ID of the parent station for the entrance.",
-       :value "2"})}
+       :value 2})}
     {:field-name "parent_station",
      :required false,
      :details
@@ -154,25 +154,25 @@
      ("* 0 (or empty) - indicates that there is no accessibility information for the stop"
       {:description
        "indicates that at least some vehicles at this stop can be boarded by a rider in a wheelchair",
-       :value "1"}
+       :value 1}
       {:description "wheelchair boarding is not possible at this stop",
-       :value "2"}
+       :value 2}
       "When a stop is part of a larger station complex, as indicated by a stop with a parent_station value, the stop's wheelchair_boarding field has the following additional semantics:"
       "* 0 (or empty) - the stop will inherit its wheelchair_boarding value from the parent station, if specified in the parent"
       {:description
        "there exists some accessible path from outside the station to the specific stop / platform",
-       :value "1"}
+       :value 1}
       {:description
        "there exists no accessible path from outside the station to the specific stop / platform",
-       :value "2"}
+       :value 2}
       "For station entrances, the wheelchair_boarding field has the following additional semantics:"
       "* 0 (or empty) - the station entrance will inherit its wheelchair_boarding value from the parent station, if specified in the parent"
       {:description
        "the station entrance is wheelchair accessible (e.g. an elevator is available to platforms if they are not at-grade)",
-       :value "1"}
+       :value 1}
       {:description
        "there exists no accessible path from the entrance to station platforms",
-       :value "2"})})}
+       :value 2})})}
   {:filename "routes.txt",
    :fields
    ({:field-name "route_id",
@@ -203,28 +203,28 @@
      :values
      ({:description
        "Tram, Streetcar, Light rail. Any light rail or street level system within a metropolitan area.",
-       :value "0"}
+       :value 0}
       {:description
        "Subway, Metro. Any underground rail system within a metropolitan area.",
-       :value "1"}
+       :value 1}
       {:description
        "Rail. Used for intercity or long-distance travel.",
-       :value "2"}
+       :value 2}
       {:description
        "Bus. Used for short- and long-distance bus routes.",
-       :value "3"}
+       :value 3}
       {:description
        "Ferry. Used for short- and long-distance boat service.",
-       :value "4"}
+       :value 4}
       {:description
        "Cable car. Used for street-level cable cars where the cable runs beneath the car.",
-       :value "5"}
+       :value 5}
       {:description
        "Gondola, Suspended cable car. Typically used for aerial cable cars where the car is suspended from the cable.",
-       :value "6"}
+       :value 6}
       {:description
        "Funicular. Any rail system designed for steep inclines.",
-       :value "7"})}
+       :value 7})}
     {:field-name "route_url",
      :required false,
      :details
@@ -270,10 +270,10 @@
      "The direction_id field contains a binary value that indicates the direction of travel for a trip. Use this field to distinguish between bi-directional trips with the same route_id. This field is not used in routing; it provides a way to separate trips by direction when publishing time tables. You can specify names for each direction with the trip_headsign field.",
      :values
      ({:description "travel in one direction (e.g. outbound travel)",
-       :value "0"}
+       :value 0}
       {:description
        "travel in the opposite direction (e.g. inbound travel)",
-       :value "1"}
+       :value 1}
       "For example, you could use the trip_headsign and direction_id fields together to assign a name to travel in each direction for a set of trips. A trips.txt file could contain these rows for use in time tables:"
       "* trip_id,...,trip_headsign,direction_id"
       "* 1234,...,Airport,0"
@@ -293,10 +293,10 @@
      :values
      ({:description
        "indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair",
-       :value "1"}
+       :value 1}
       {:description
        "indicates that no riders in wheelchairs can be accommodated on this trip",
-       :value "2"})}
+       :value 2})}
     {:field-name "bikes_allowed",
      :required false,
      :details
@@ -304,10 +304,10 @@
      :values
      ({:description
        "indicates that the vehicle being used on this particular trip can accommodate at least one bicycle",
-       :value "1"}
+       :value 1}
       {:description
        "indicates that no bicycles are allowed on this trip",
-       :value "2"})})}
+       :value 2})})}
   {:filename "stop_times.txt",
    :fields
    ({:field-name "trip_id",
@@ -339,23 +339,22 @@
      :details
      "The pickup_type field indicates whether passengers are picked up at a stop as part of the normal schedule or whether a pickup at the stop is not available. This field also allows the transit agency to indicate that passengers must call the agency or notify the driver to arrange a pickup at a particular stop. Valid values for this field are:",
      :values
-     ({:description "Regularly scheduled pickup", :value "0"}
-      {:description "No pickup available", :value "1"}
-      {:description "Must phone agency to arrange pickup", :value "2"}
+     ({:description "Regularly scheduled pickup", :value 0}
+      {:description "No pickup available", :value 1}
+      {:description "Must phone agency to arrange pickup", :value 2}
       {:description "Must coordinate with driver to arrange pickup",
-       :value "3"}
+       :value 3}
       "The default value for this field is 0.")}
     {:field-name "drop_off_type",
      :required false,
      :details
      "The drop_off_type field indicates whether passengers are dropped off at a stop as part of the normal schedule or whether a drop off at the stop is not available. This field also allows the transit agency to indicate that passengers must call the agency or notify the driver to arrange a drop off at a particular stop. Valid values for this field are:",
      :values
-     ({:description "Regularly scheduled drop off", :value "0"}
-      {:description "No drop off available", :value "1"}
-      {:description "Must phone agency to arrange drop off",
-       :value "2"}
+     ({:description "Regularly scheduled drop off", :value 0}
+      {:description "No drop off available", :value 1}
+      {:description "Must phone agency to arrange drop off", :value 2}
       {:description "Must coordinate with driver to arrange drop off",
-       :value "3"}
+       :value 3}
       "The default value for this field is 0.")}
     {:field-name "shape_dist_traveled",
      :required false,
@@ -367,8 +366,8 @@
      "The timepoint field can be used to indicate if the specified arrival and departure times for a stop are strictly adhered to by the transit vehicle or if they are instead approximate and/or interpolated times. The field allows a GTFS producer to provide interpolated stop times that potentially incorporate local knowledge, but still indicate if the times are approximate. For stop-time entries with specified arrival and departure times, valid values for this field are:",
      :values
      ("* empty - Times are considered exact."
-      {:description "Times are considered approximate.", :value "0"}
-      {:description "Times are considered exact.", :value "1"}
+      {:description "Times are considered approximate.", :value 0}
+      {:description "Times are considered exact.", :value 1}
       "For stop-time entries without specified arrival and departure times, feed consumers must interpolate arrival and departure times. Feed producers may optionally indicate that such an entry is not a timepoint (value=0) but it is an error to mark a entry as a timepoint (value=1) without specifying arrival and departure times.")})}
   {:filename "calendar.txt",
    :fields
@@ -451,16 +450,16 @@
      :details
      "The payment_method field indicates when the fare must be paid. Valid values for this field are:",
      :values
-     ({:description "Fare is paid on board.", :value "0"}
-      {:description "Fare must be paid before boarding.", :value "1"})}
+     ({:description "Fare is paid on board.", :value 0}
+      {:description "Fare must be paid before boarding.", :value 1})}
     {:field-name "transfers",
      :required true,
      :details
      "The transfers field specifies the number of transfers permitted on this fare. Valid values for this field are:",
      :values
-     ({:description "No transfers permitted on this fare.", :value "0"}
-      {:description "Passenger may transfer once.", :value "1"}
-      {:description "Passenger may transfer twice.", :value "2"}
+     ({:description "No transfers permitted on this fare.", :value 0}
+      {:description "Passenger may transfer once.", :value 1}
+      {:description "Passenger may transfer twice.", :value 2}
       "* (empty) - If this field is empty, unlimited transfers are permitted.")}
     {:field-name "agency_id",
      :required false,
@@ -540,7 +539,7 @@
      ("* 0 or (empty) - Frequency-based trips are not exactly scheduled. This is the default behavior."
       {:description
        "Frequency-based trips are exactly scheduled. For a frequencies.txt row, trips are scheduled starting with trip_start_time = start_time + x * headway_secs for all x in (0, 1, 2, ...) where trip_start_time < end_time.",
-       :value "1"}
+       :value 1}
       "The value of exact_times must be the same for all frequencies.txt rows with the same trip_id. If exact_times is 1 and a frequencies.txt row has a start_time equal to end_time, no trip must be scheduled. When exact_times is 1, care must be taken to choose an end_time value that is greater than the last desired trip start time but less than the last desired trip start time + headway_secs.")})}
   {:filename "transfers.txt",
    :fields
@@ -560,13 +559,13 @@
      ("* 0 or (empty) - This is a recommended transfer point between routes."
       {:description
        "This is a timed transfer point between two routes. The departing vehicle is expected to wait for the arriving one, with sufficient time for a passenger to transfer between routes.",
-       :value "1"}
+       :value 1}
       {:description
        "This transfer requires a minimum amount of time between arrival and departure to ensure a connection. The time required to transfer is specified by min_transfer_time.",
-       :value "2"}
+       :value 2}
       {:description
        "Transfers are not possible between routes at this location.",
-       :value "3"})}
+       :value 3})}
     {:field-name "min_transfer_time",
      :required false,
      :details

--- a/resources/gtfs/reference.edn
+++ b/resources/gtfs/reference.edn
@@ -1,4 +1,5 @@
 {:meta {:revised "August 9, 2018"
+        :original "https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md"
         :description "This document explains the types of files that comprise a GTFS transit feed and defines the fields used in all of those files."}
  :definitions {:required "The field column must be included in your feed, and a value must be provided for each record. Some required fields permit an empty string as a value. To enter an empty string, just omit any text between the commas for that field. Note that 0 is interpreted as \"a string of value 0\", and is not an empty string. Please see the field definition for details"
                :optional "The field column may be omitted from your feed. If you choose to include an optional column, each record in your feed must have a value for that column. You may include an empty string as a value for records that do not have values for the column. Some optional fields permit an empty string as a value. To enter an empty string, just omit any text between the commas for that field. Note that 0 is interpreted as \"a string of value 0\", and is not an empty string."
@@ -131,7 +132,8 @@
      :details
      "The location_type field identifies whether this stop ID represents a stop, station, or station entrance. If no location type is specified, or the location_type is blank, stop IDs are treated as stops. Stations may have different properties from stops when they are represented on a map or used in trip planning.  The location type field can have the following values:",
      :values
-     ("* 0 or blank - Stop. A location where passengers board or disembark from a transit vehicle."
+     ({:value 0
+       :description "Stop. A location where passengers board or disembark from a transit vehicle."}
       {:description
        "Station. A physical structure or area that contains one or more stop.",
        :value 1}
@@ -151,14 +153,16 @@
      :details
      "The wheelchair_boarding field identifies whether wheelchair boardings are possible from the specified stop, station, or station entrance. The field can have the following values:",
      :values
-     ("* 0 (or empty) - indicates that there is no accessibility information for the stop"
+     ({:value 0
+       :description "indicates that there is no accessibility information for the stop"}
       {:description
        "indicates that at least some vehicles at this stop can be boarded by a rider in a wheelchair",
        :value 1}
       {:description "wheelchair boarding is not possible at this stop",
        :value 2}
       "When a stop is part of a larger station complex, as indicated by a stop with a parent_station value, the stop's wheelchair_boarding field has the following additional semantics:"
-      "* 0 (or empty) - the stop will inherit its wheelchair_boarding value from the parent station, if specified in the parent"
+      {:value 0
+       :description "the stop will inherit its wheelchair_boarding value from the parent station, if specified in the parent"}
       {:description
        "there exists some accessible path from outside the station to the specific stop / platform",
        :value 1}
@@ -166,7 +170,8 @@
        "there exists no accessible path from outside the station to the specific stop / platform",
        :value 2}
       "For station entrances, the wheelchair_boarding field has the following additional semantics:"
-      "* 0 (or empty) - the station entrance will inherit its wheelchair_boarding value from the parent station, if specified in the parent"
+      {:value 0
+       :description "the station entrance will inherit its wheelchair_boarding value from the parent station, if specified in the parent"}
       {:description
        "the station entrance is wheelchair accessible (e.g. an elevator is available to platforms if they are not at-grade)",
        :value 1}
@@ -267,17 +272,17 @@
     {:field-name "direction_id",
      :required false,
      :details
-     "The direction_id field contains a binary value that indicates the direction of travel for a trip. Use this field to distinguish between bi-directional trips with the same route_id. This field is not used in routing; it provides a way to separate trips by direction when publishing time tables. You can specify names for each direction with the trip_headsign field.",
+     "The direction_id field contains a binary value that indicates the direction of travel for a trip. Use this field to distinguish between bi-directional trips with the same route_id. This field is not used in routing; it provides a way to separate trips by direction when publishing time tables. You can specify names for each direction with the trip_headsign field.
+     For example, you could use the trip_headsign and direction_id fields together to assign a name to travel in each direction for a set of trips. A trips.txt file could contain these rows for use in time tables:
+     * trip_id,...,trip_headsign,direction_id
+     * 1234,...,Airport,0
+     * 1505,...,Downtown,1",
      :values
      ({:description "travel in one direction (e.g. outbound travel)",
        :value 0}
       {:description
        "travel in the opposite direction (e.g. inbound travel)",
-       :value 1}
-      "For example, you could use the trip_headsign and direction_id fields together to assign a name to travel in each direction for a set of trips. A trips.txt file could contain these rows for use in time tables:"
-      "* trip_id,...,trip_headsign,direction_id"
-      "* 1234,...,Airport,0"
-      "* 1505,...,Downtown,1")}
+       :value 1})}
     {:field-name "block_id",
      :required false,
      :details
@@ -288,10 +293,11 @@
      "The shape_id field contains an ID that defines a shape for the trip. This value is referenced from the shapes.txt file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip."}
     {:field-name "wheelchair_accessible",
      :required false,
-     :details
-     "* 0 (or empty) - indicates that there is no accessibility information for the trip",
+     :details "accessibility information",
      :values
-     ({:description
+     ({:value 0
+       :description "indicates that there is no accessibility information for the trip"}
+      {:description
        "indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair",
        :value 1}
       {:description
@@ -299,10 +305,11 @@
        :value 2})}
     {:field-name "bikes_allowed",
      :required false,
-     :details
-     "0 (or empty) - indicates that there is no bike information for the trip",
+     :details "indicates if bikes are allowed inside vehicle",
      :values
-     ({:description
+     ({:value 0
+       :description "indicates that there is no bike information for the trip"}
+      {:description
        "indicates that the vehicle being used on this particular trip can accommodate at least one bicycle",
        :value 1}
       {:description
@@ -425,11 +432,14 @@
     {:field-name "exception_type",
      :required true,
      :details
-     "The exception_type indicates whether service is available on the date specified in the date field.",
+     "The exception_type indicates whether service is available on the date specified in the date field.
+
+     For example, suppose a route has one set of trips available on holidays and another set of trips available on all other days. You could have one service_id that corresponds to the regular service schedule and another service_id that corresponds to the holiday schedule. For a particular holiday, you would use the calendar_dates.txt file to add the holiday to the holiday service_id and to remove the holiday from the regular service_id schedule.",
      :values
-     ("*  A value of 1 indicates that service has been added for the specified date."
-      "* A value of 2 indicates that service has been removed for the specified date."
-      "For example, suppose a route has one set of trips available on holidays and another set of trips available on all other days. You could have one service_id that corresponds to the regular service schedule and another service_id that corresponds to the holiday schedule. For a particular holiday, you would use the calendar_dates.txt file to add the holiday to the holiday service_id and to remove the holiday from the regular service_id schedule.")})}
+     ({:value 1
+       :description "service added for the specified date."}
+      {:value 2
+       :description "service removed for the specified date."})})}
   {:filename "fare_attributes.txt",
    :fields
    ({:field-name "fare_id",
@@ -455,12 +465,13 @@
     {:field-name "transfers",
      :required true,
      :details
-     "The transfers field specifies the number of transfers permitted on this fare. Valid values for this field are:",
+     "The transfers field specifies the number of transfers permitted on this fare.
+      Valid values for this field are:",
      :values
-     ({:description "No transfers permitted on this fare.", :value 0}
+     ({:description "unlimited transfers are permitted" :value ""}
+      {:description "No transfers permitted on this fare.", :value 0}
       {:description "Passenger may transfer once.", :value 1}
-      {:description "Passenger may transfer twice.", :value 2}
-      "* (empty) - If this field is empty, unlimited transfers are permitted.")}
+      {:description "Passenger may transfer twice.", :value 2})}
     {:field-name "agency_id",
      :required false,
      :details
@@ -534,13 +545,17 @@
     {:field-name "exact_times",
      :required false,
      :details
-     "The exact_times field determines if frequency-based trips should be exactly scheduled based on the specified headway information. Valid values for this field are:",
+     "The exact_times field determines if frequency-based trips should be exactly scheduled based on the specified headway information.
+
+      The value of exact_times must be the same for all frequencies.txt rows with the same trip_id. If exact_times is 1 and a frequencies.txt row has a start_time equal to end_time, no trip must be scheduled. When exact_times is 1, care must be taken to choose an end_time value that is greater than the last desired trip start time but less than the last desired trip start time + headway_secs.
+
+      Valid values for this field are:",
      :values
-     ("* 0 or (empty) - Frequency-based trips are not exactly scheduled. This is the default behavior."
+     ({:value 0
+       :description "Frequency-based trips are not exactly scheduled. This is the default behavior."}
       {:description
        "Frequency-based trips are exactly scheduled. For a frequencies.txt row, trips are scheduled starting with trip_start_time = start_time + x * headway_secs for all x in (0, 1, 2, ...) where trip_start_time < end_time.",
-       :value 1}
-      "The value of exact_times must be the same for all frequencies.txt rows with the same trip_id. If exact_times is 1 and a frequencies.txt row has a start_time equal to end_time, no trip must be scheduled. When exact_times is 1, care must be taken to choose an end_time value that is greater than the last desired trip start time but less than the last desired trip start time + headway_secs.")})}
+       :value 1})})}
   {:filename "transfers.txt",
    :fields
    ({:field-name "from_stop_id",
@@ -556,7 +571,8 @@
      :details
      "The transfer_type field specifies the type of connection for the specified (from_stop_id, to_stop_id) pair. Valid values for this field are:",
      :values
-     ("* 0 or (empty) - This is a recommended transfer point between routes."
+     ({:value 0
+       :description "This is a recommended transfer point between routes."}
       {:description
        "This is a timed transfer point between two routes. The departing vehicle is expected to wait for the arriving one, with sufficient time for a passenger to transfer between routes.",
        :value 1}

--- a/resources/gtfs/reference.edn
+++ b/resources/gtfs/reference.edn
@@ -1,0 +1,592 @@
+{:meta {:revised "August 9, 2018"
+        :description "This document explains the types of files that comprise a GTFS transit feed and defines the fields used in all of those files."}
+ :definitions {:required "The field column must be included in your feed, and a value must be provided for each record. Some required fields permit an empty string as a value. To enter an empty string, just omit any text between the commas for that field. Note that 0 is interpreted as \"a string of value 0\", and is not an empty string. Please see the field definition for details"
+               :optional "The field column may be omitted from your feed. If you choose to include an optional column, each record in your feed must have a value for that column. You may include an empty string as a value for records that do not have values for the column. Some optional fields permit an empty string as a value. To enter an empty string, just omit any text between the commas for that field. Note that 0 is interpreted as \"a string of value 0\", and is not an empty string."
+               :unique   " The field contains a value that maps to a single distinct entity within the column. For example, if a route is assigned the ID 1A, then no other route may use that route ID. However, you may assign the ID 1A to a location because locations are a different type of entity than routes"}
+ :feed-files
+ ({:filename "agency.txt",
+   :required "Required",
+   :defines
+   "One or more transit agencies that provide the data in this feed."}
+  {:filename "stops.txt",
+   :required "Required",
+   :defines
+   "Individual locations where vehicles pick up or drop off passengers."}
+  {:filename "routes.txt",
+   :required "Required",
+   :defines
+   "Transit routes. A route is a group of trips that are displayed to riders as a single service."}
+  {:filename "trips.txt",
+   :required "Required",
+   :defines
+   "Trips for each route. A trip is a sequence of two or more stops that occurs at specific time."}
+  {:filename "stop_times.txt",
+   :required "Required",
+   :defines
+   "Times that a vehicle arrives at and departs from individual stops for each trip."}
+  {:filename "calendar.txt",
+   :required "Required",
+   :defines
+   "Dates for service IDs using a weekly schedule. Specify when service starts and ends, as well as days of the week where service is available."}
+  {:filename "calendar_dates.txt",
+   :required "Optional",
+   :defines
+   "Exceptions for the service IDs defined in the calendar.txt file. If calendar.txt includes ALL dates of service, this file may be specified instead of calendar.txt."}
+  {:filename "fare_attributes.txt",
+   :required "Optional",
+   :defines "Fare information for a transit organization's routes."}
+  {:filename "fare_rules.txt",
+   :required "Optional",
+   :defines
+   "Rules for applying fare information for a transit organization's routes."}
+  {:filename "shapes.txt",
+   :required "Optional",
+   :defines
+   "Rules for drawing lines on a map to represent a transit organization's routes."}
+  {:filename "frequencies.txt",
+   :required "Optional",
+   :defines
+   "Headway (time between trips) for routes with variable frequency of service."}
+  {:filename "transfers.txt",
+   :required "Optional",
+   :defines
+   "Rules for making connections at transfer points between routes."}
+  {:filename "feed_info.txt",
+   :required "Optional",
+   :defines
+   "Additional information about the feed itself, including publisher, version, and expiration information."}),
+ :field-definitions
+ ({:filename "agency.txt",
+   :fields
+   ({:field-name "agency_id",
+     :required "Optional",
+     :details
+     "The agency_id field is an ID that uniquely identifies a transit agency. A transit feed may represent data from more than one agency. The agency_id is dataset unique. This field is optional for transit feeds that only contain data for a single agency."}
+    {:field-name "agency_name",
+     :required "Required",
+     :details
+     "The agency_name field contains the full name of the transit agency. Google Maps will display this name."}
+    {:field-name "agency_url",
+     :required "Required",
+     :details
+     "The agency_url field contains the URL of the transit agency. The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
+    {:field-name "agency_timezone",
+     :required "Required",
+     :details
+     "The agency_timezone field contains the timezone where the transit agency is located. Timezone names never contain the space character but may contain an underscore. Please refer to http://en.wikipedia.org/wiki/List_of_tz_zones for a list of valid values. If multiple agencies are specified in the feed, each must have the same agency_timezone."}
+    {:field-name "agency_lang",
+     :required "Optional",
+     :details
+     "The agency_lang field contains a two-letter ISO 639-1 code for the primary language used by this transit agency. The language code is case-insensitive (both en and EN are accepted). This setting defines capitalization rules and other language-specific settings for all text contained in this transit agency's feed. Please refer to http://www.loc.gov/standards/iso639-2/php/code_list.php for a list of valid values."}
+    {:field-name "agency_phone",
+     :required "Optional",
+     :details
+     "The agency_phone field contains a single voice telephone number for the specified agency. This field is a string value that presents the telephone number as typical for the agency's service area. It can and should contain punctuation marks to group the digits of the number. Dialable text (for example, TriMet's \"503-238-RIDE\") is permitted, but the field must not contain any other descriptive text."}
+    {:field-name "agency_fare_url",
+     :required "Optional",
+     :details
+     "The agency_fare_url specifies the URL of a web page that allows a rider to purchase tickets or other fare instruments for that agency online. The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
+    {:field-name "agency_email",
+     :required "Optional",
+     :details
+     "Contains a single valid email address actively monitored by the agency’s customer service department. This email address will be considered a direct contact point where transit riders can reach a customer service representative at the agency."})}
+  {:filename "stops.txt",
+   :fields
+   ({:field-name "stop_id",
+     :required "Required",
+     :details
+     "The stop_id field contains an ID that uniquely identifies a stop, station, or station entrance. Multiple routes may use the same stop. The stop_id is used by systems as an internal identifier of this record (e.g., primary key in database), and therefore the stop_id must be dataset unique."}
+    {:field-name "stop_code",
+     :required "Optional",
+     :details
+     "The stop_code field contains short text or a number that uniquely identifies the stop for passengers. Stop codes are often used in phone-based transit information systems or printed on stop signage to make it easier for riders to get a stop schedule or real-time arrival information for a particular stop.  The stop_code field contains short text or a number that uniquely identifies the stop for passengers. The stop_code can be the same as stop_id if it is passenger-facing. This field should be left blank for stops without a code presented to passengers."}
+    {:field-name "stop_name",
+     :required "Required",
+     :details
+     "The stop_name field contains the name of a stop, station, or station entrance. Please use a name that people will understand in the local and tourist vernacular."}
+    {:field-name "stop_desc",
+     :required "Optional",
+     :details
+     "The stop_desc field contains a description of a stop. Please provide useful, quality information. Do not simply duplicate the name of the stop."}
+    {:field-name "stop_lat",
+     :required "Required",
+     :details
+     "The stop_lat field contains the latitude of a stop, station, or station entrance. The field value must be a valid WGS 84 latitude."}
+    {:field-name "stop_lon",
+     :required "Required",
+     :details
+     "The stop_lon field contains the longitude of a stop, station, or station entrance. The field value must be a valid WGS 84 longitude value from -180 to 180."}
+    {:field-name "zone_id",
+     :required "Optional",
+     :details
+     "The zone_id field defines the fare zone for a stop ID. Zone IDs are required if you want to provide fare information using fare_rules.txt. If this stop ID represents a station, the zone ID is ignored."}
+    {:field-name "stop_url",
+     :required "Optional",
+     :details
+     "The stop_url field contains the URL of a web page about a particular stop. This should be different from the agency_url and the route_url fields.  The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
+    {:field-name "location_type",
+     :required "Optional",
+     :details
+     "The location_type field identifies whether this stop ID represents a stop, station, or station entrance. If no location type is specified, or the location_type is blank, stop IDs are treated as stops. Stations may have different properties from stops when they are represented on a map or used in trip planning.  The location type field can have the following values:",
+     :values
+     ("* 0 or blank - Stop. A location where passengers board or disembark from a transit vehicle."
+      {:description
+       "Station. A physical structure or area that contains one or more stop.",
+       :value "1"}
+      {:description
+       "Station Entrance/Exit. A location where passengers can enter or exit a station from the street. The stop entry must also specify a parent_station value referencing the stop ID of the parent station for the entrance.",
+       :value "2"})}
+    {:field-name "parent_station",
+     :required "Optional",
+     :details
+     "For stops that are physically located inside stations, the parent_station field identifies the station associated with the stop. To use this field, stops.txt must also contain a row where this stop ID is assigned location type=1."}
+    {:field-name "stop_timezone",
+     :required "Optional",
+     :details
+     "The stop_timezone field contains the timezone in which this stop, station, or station entrance is located. Please refer to Wikipedia List of Timezones for a list of valid values. If omitted, the stop should be assumed to be located in the timezone specified by agency_timezone in agency.txt.   When a stop has a parent station, the stop is considered to be in the timezone specified by the parent station's stop_timezone value. If the parent has no stop_timezone value, the stops that belong to that station are assumed to be in the timezone specified by agency_timezone, even if the stops have their own stop_timezone values. In other words, if a given stop has a parent_station value, any stop_timezone value specified for that stop must be ignored.  Even if stop_timezone values are provided in stops.txt, the times in stop_times.txt should continue to be specified as time since midnight in the timezone specified by agency_timezone in agency.txt. This ensures that the time values in a trip always increase over the course of a trip, regardless of which timezones the trip crosses."}
+    {:field-name "wheelchair_boarding",
+     :required "Optional",
+     :details
+     "The wheelchair_boarding field identifies whether wheelchair boardings are possible from the specified stop, station, or station entrance. The field can have the following values:",
+     :values
+     ("* 0 (or empty) - indicates that there is no accessibility information for the stop"
+      {:description
+       "indicates that at least some vehicles at this stop can be boarded by a rider in a wheelchair",
+       :value "1"}
+      {:description "wheelchair boarding is not possible at this stop",
+       :value "2"}
+      "When a stop is part of a larger station complex, as indicated by a stop with a parent_station value, the stop's wheelchair_boarding field has the following additional semantics:"
+      "* 0 (or empty) - the stop will inherit its wheelchair_boarding value from the parent station, if specified in the parent"
+      {:description
+       "there exists some accessible path from outside the station to the specific stop / platform",
+       :value "1"}
+      {:description
+       "there exists no accessible path from outside the station to the specific stop / platform",
+       :value "2"}
+      "For station entrances, the wheelchair_boarding field has the following additional semantics:"
+      "* 0 (or empty) - the station entrance will inherit its wheelchair_boarding value from the parent station, if specified in the parent"
+      {:description
+       "the station entrance is wheelchair accessible (e.g. an elevator is available to platforms if they are not at-grade)",
+       :value "1"}
+      {:description
+       "there exists no accessible path from the entrance to station platforms",
+       :value "2"})})}
+  {:filename "routes.txt",
+   :fields
+   ({:field-name "route_id",
+     :required "Required",
+     :details
+     "The route_id field contains an ID that uniquely identifies a route. The route_id is dataset unique."}
+    {:field-name "agency_id",
+     :required "Optional",
+     :details
+     "The agency_id field defines an agency for the specified route. This value is referenced from the agency.txt file. Use this field when you are providing data for routes from more than one agency."}
+    {:field-name "route_short_name",
+     :required "Required",
+     :details
+     "The route_short_name contains the short name of a route. This will often be a short, abstract identifier like \"32\", \"100X\", or \"Green\" that riders use to identify a route, but which doesn't give any indication of what places the route serves. At least one of route_short_name or route_long_name must be specified, or potentially both if appropriate. If the route does not have a short name, please specify a route_long_name and use an empty string as the value for this field."}
+    {:field-name "route_long_name",
+     :required "Required",
+     :details
+     "The route_long_name contains the full name of a route. This name is generally more descriptive than the route_short_name and will often include the route's destination or stop. At least one of route_short_name or route_long_name must be specified, or potentially both if appropriate. If the route does not have a long name, please specify a route_short_name and use an empty string as the value for this field."}
+    {:field-name "route_desc",
+     :required "Optional",
+     :details
+     "The route_desc field contains a description of a route. Please provide useful, quality information. Do not simply duplicate the name of the route. For example, \"A trains operate between Inwood-207 St, Manhattan and Far Rockaway-Mott Avenue, Queens at all times. Also from about 6AM until about midnight, additional A trains operate between Inwood-207 St and Lefferts Boulevard (trains typically alternate between Lefferts Blvd and Far Rockaway).\""}
+    {:field-name "route_type",
+     :required "Required",
+     :details
+     "The route_type field describes the type of transportation used on a route. Valid values for this field are:",
+     :values
+     ({:description
+       "Tram, Streetcar, Light rail. Any light rail or street level system within a metropolitan area.",
+       :value "0"}
+      {:description
+       "Subway, Metro. Any underground rail system within a metropolitan area.",
+       :value "1"}
+      {:description
+       "Rail. Used for intercity or long-distance travel.",
+       :value "2"}
+      {:description
+       "Bus. Used for short- and long-distance bus routes.",
+       :value "3"}
+      {:description
+       "Ferry. Used for short- and long-distance boat service.",
+       :value "4"}
+      {:description
+       "Cable car. Used for street-level cable cars where the cable runs beneath the car.",
+       :value "5"}
+      {:description
+       "Gondola, Suspended cable car. Typically used for aerial cable cars where the car is suspended from the cable.",
+       :value "6"}
+      {:description
+       "Funicular. Any rail system designed for steep inclines.",
+       :value "7"})}
+    {:field-name "route_url",
+     :required "Optional",
+     :details
+     "The route_url field contains the URL of a web page about that particular route. This should be different from the agency_url.  The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
+    {:field-name "route_color",
+     :required "Optional",
+     :details
+     "In systems that have colors assigned to routes, the route_color field defines a color that corresponds to a route. The color must be provided as a six-character hexadecimal number, for example, 00FFFF. If no color is specified, the default route color is white (FFFFFF).  The color difference between route_color and route_text_color should provide sufficient contrast when viewed on a black and white screen. The W3C Techniques for Accessibility Evaluation And Repair Tools document offers a useful algorithm for evaluating color contrast. There are also helpful online tools for choosing contrasting colors, including the snook.ca Color Contrast Check application."}
+    {:field-name "route_text_color",
+     :required "Optional",
+     :details
+     "The route_text_color field can be used to specify a legible color to use for text drawn against a background of route_color. The color must be provided as a six-character hexadecimal number, for example, FFD700. If no color is specified, the default text color is black (000000).  The color difference between route_color and route_text_color should provide sufficient contrast when viewed on a black and white screen."}
+    {:field-name "route_sort_order",
+     :required "Optional",
+     :details
+     "The route_sort_order field can be used to order the routes in a way which is ideal for presentation to customers. It must be a non-negative integer. Routes with smaller route_sort_order values should be displayed before routes with larger route_sort_order values."})}
+  {:filename "trips.txt",
+   :fields
+   ({:field-name "route_id",
+     :required "Required",
+     :details
+     "The route_id field contains an ID that uniquely identifies a route. This value is referenced from the routes.txt file."}
+    {:field-name "service_id",
+     :required "Required",
+     :details
+     "The service_id contains an ID that uniquely identifies a set of dates when service is available for one or more routes. This value is referenced from the calendar.txt or calendar_dates.txt file."}
+    {:field-name "trip_id",
+     :required "Required",
+     :details
+     "The trip_id field contains an ID that identifies a trip. The trip_id is dataset unique."}
+    {:field-name "trip_headsign",
+     :required "Optional",
+     :details
+     "The trip_headsign field contains the text that appears on a sign that identifies the trip's destination to passengers. Use this field to distinguish between different patterns of service in the same route. If the headsign changes during a trip, you can override the trip_headsign by specifying values for the stop_headsign field in stop_times.txt."}
+    {:field-name "trip_short_name",
+     :required "Optional",
+     :details
+     "The trip_short_name field contains the text that appears in schedules and sign boards to identify the trip to passengers, for example, to identify train numbers for commuter rail trips. If riders do not commonly rely on trip names, please leave this field blank.  A trip_short_name value, if provided, should uniquely identify a trip within a service day; it should not be used for destination names or limited/express designations."}
+    {:field-name "direction_id",
+     :required "Optional",
+     :details
+     "The direction_id field contains a binary value that indicates the direction of travel for a trip. Use this field to distinguish between bi-directional trips with the same route_id. This field is not used in routing; it provides a way to separate trips by direction when publishing time tables. You can specify names for each direction with the trip_headsign field.",
+     :values
+     ({:description "travel in one direction (e.g. outbound travel)",
+       :value "0"}
+      {:description
+       "travel in the opposite direction (e.g. inbound travel)",
+       :value "1"}
+      "For example, you could use the trip_headsign and direction_id fields together to assign a name to travel in each direction for a set of trips. A trips.txt file could contain these rows for use in time tables:"
+      "* trip_id,...,trip_headsign,direction_id"
+      "* 1234,...,Airport,0"
+      "* 1505,...,Downtown,1")}
+    {:field-name "block_id",
+     :required "Optional",
+     :details
+     "The block_id field identifies the block to which the trip belongs. A block consists of a single trip or many sequential trips made using the same vehicle, defined by shared service day and block_id. A block_id can have trips with different service days, making distinct blocks. (See example below)"}
+    {:field-name "shape_id",
+     :required "Optional",
+     :details
+     "The shape_id field contains an ID that defines a shape for the trip. This value is referenced from the shapes.txt file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip."}
+    {:field-name "wheelchair_accessible",
+     :required "Optional",
+     :details
+     "* 0 (or empty) - indicates that there is no accessibility information for the trip",
+     :values
+     ({:description
+       "indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair",
+       :value "1"}
+      {:description
+       "indicates that no riders in wheelchairs can be accommodated on this trip",
+       :value "2"})}
+    {:field-name "bikes_allowed",
+     :required "Optional",
+     :details
+     "0 (or empty) - indicates that there is no bike information for the trip",
+     :values
+     ({:description
+       "indicates that the vehicle being used on this particular trip can accommodate at least one bicycle",
+       :value "1"}
+      {:description
+       "indicates that no bicycles are allowed on this trip",
+       :value "2"})})}
+  {:filename "stop_times.txt",
+   :fields
+   ({:field-name "trip_id",
+     :required "Required",
+     :details
+     "The trip_id field contains an ID that identifies a trip. This value is referenced from the trips.txt file."}
+    {:field-name "arrival_time",
+     :required "Required",
+     :details
+     "The arrival_time specifies the arrival time at a specific stop for a specific trip on a route. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. If you don't have separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time.Scheduled stops where the vehicle strictly adheres to the specified arrival and departure times are timepoints. For example, if a transit vehicle arrives at a stop before the scheduled departure time, it will hold until the departure time. If this stop is not a timepoint, use either an empty string value for the arrival_time field or provide an interpolated time. Further, indicate that interpolated times are provided via the timepoint field with a value of zero. If interpolated times are indicated with timepoint=0, then time points must be indicated with a value of 1 for the timepoint field. Provide arrival times for all stops that are time points.An arrival time must be specified for the first and the last stop in a trip. Times must be eight digits in HH:MM:SS format (H:MM:SS is also accepted, if the hour begins with 0). Do not pad times with spaces. The following columns list stop times for a trip and the proper way to express those times in the arrival_time field:"}
+    {:field-name "departure_time",
+     :required "Required",
+     :details
+     "The departure_time specifies the departure time from a specific stop for a specific trip on a route. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. If you don't have separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time.Scheduled stops where the vehicle strictly adheres to the specified arrival and departure times are timepoints. For example, if a transit vehicle arrives at a stop before the scheduled departure time, it will hold until the departure time. If this stop is not a timepoint, use either an empty string value for the departure_time field or provide an interpolated time (further, indicate that interpolated times are provided via the timepoint field with a value of zero). If interpolated times are indicated with timepoint=0, then time points must be indicated with a value of 1 for the timepoint field. Provide departure times for all stops that are time points.A departure time must be specified for the first and the last stop in a trip even if the vehicle does not allow boarding at the last stop.  Times must be eight digits in HH:MM:SS format (H:MM:SS is also accepted, if the hour begins with 0). Do not pad times with spaces. The following columns list stop times for a trip and the proper way to express those times in the departure_time field:"}
+    {:field-name "stop_id",
+     :required "Required",
+     :details
+     "The stop_id field contains an ID that uniquely identifies a stop. Multiple routes may use the same stop. The stop_id is referenced from the stops.txt file. If location_type is used in stops.txt, all stops referenced in stop_times.txt must have location_type of 0.  Where possible, stop_id values should remain consistent between feed updates. In other words, stop A with stop_id 1 should have stop_id 1 in all subsequent data updates. If a stop is not a time point, enter blank values for arrival_time and departure_time."}
+    {:field-name "stop_sequence",
+     :required "Required",
+     :details
+     "The stop_sequence field identifies the order of the stops for a particular trip. The values for stop_sequence must be non-negative integers, and they must increase along the trip.  For example, the first stop on the trip could have a stop_sequence of 1, the second stop on the trip could have a stop_sequence of 23, the third stop could have a stop_sequence of 40, and so on."}
+    {:field-name "stop_headsign",
+     :required "Optional",
+     :details
+     "The stop_headsign field contains the text that appears on a sign that identifies the trip's destination to passengers. Use this field to override the default trip_headsign when the headsign changes between stops. If this headsign is associated with an entire trip, use trip_headsign instead."}
+    {:field-name "pickup_type",
+     :required "Optional",
+     :details
+     "The pickup_type field indicates whether passengers are picked up at a stop as part of the normal schedule or whether a pickup at the stop is not available. This field also allows the transit agency to indicate that passengers must call the agency or notify the driver to arrange a pickup at a particular stop. Valid values for this field are:",
+     :values
+     ({:description "Regularly scheduled pickup", :value "0"}
+      {:description "No pickup available", :value "1"}
+      {:description "Must phone agency to arrange pickup", :value "2"}
+      {:description "Must coordinate with driver to arrange pickup",
+       :value "3"}
+      "The default value for this field is 0.")}
+    {:field-name "drop_off_type",
+     :required "Optional",
+     :details
+     "The drop_off_type field indicates whether passengers are dropped off at a stop as part of the normal schedule or whether a drop off at the stop is not available. This field also allows the transit agency to indicate that passengers must call the agency or notify the driver to arrange a drop off at a particular stop. Valid values for this field are:",
+     :values
+     ({:description "Regularly scheduled drop off", :value "0"}
+      {:description "No drop off available", :value "1"}
+      {:description "Must phone agency to arrange drop off",
+       :value "2"}
+      {:description "Must coordinate with driver to arrange drop off",
+       :value "3"}
+      "The default value for this field is 0.")}
+    {:field-name "shape_dist_traveled",
+     :required "Optional",
+     :details
+     "When used in the stop_times.txt file, the shape_dist_traveled field positions a stop as a distance from the first shape point. The shape_dist_traveled field represents a real distance traveled along the route in units such as feet or kilometers. For example, if a bus travels a distance of 5.25 kilometers from the start of the shape to the stop, the shape_dist_traveled for the stop ID would be entered as \"5.25\". This information allows the trip planner to determine how much of the shape to draw when showing part of a trip on the map. The values used for shape_dist_traveled must increase along with stop_sequence: they cannot be used to show reverse travel along a route.  The units used for shape_dist_traveled in the stop_times.txt file must match the units that are used for this field in the shapes.txt file."}
+    {:field-name "timepoint",
+     :required "Optional",
+     :details
+     "The timepoint field can be used to indicate if the specified arrival and departure times for a stop are strictly adhered to by the transit vehicle or if they are instead approximate and/or interpolated times. The field allows a GTFS producer to provide interpolated stop times that potentially incorporate local knowledge, but still indicate if the times are approximate. For stop-time entries with specified arrival and departure times, valid values for this field are:",
+     :values
+     ("* empty - Times are considered exact."
+      {:description "Times are considered approximate.", :value "0"}
+      {:description "Times are considered exact.", :value "1"}
+      "For stop-time entries without specified arrival and departure times, feed consumers must interpolate arrival and departure times. Feed producers may optionally indicate that such an entry is not a timepoint (value=0) but it is an error to mark a entry as a timepoint (value=1) without specifying arrival and departure times.")})}
+  {:filename "calendar.txt",
+   :fields
+   ({:field-name "service_id",
+     :required "Required",
+     :details
+     "The service_id contains an ID that uniquely identifies a set of dates when service is available for one or more routes. Each service_id value can appear at most once in a calendar.txt file. This value is dataset unique. It is referenced by the trips.txt file."}
+    {:field-name "monday",
+     :required "Required",
+     :details
+     "The monday field contains a binary value that indicates whether the service is valid for all Mondays."}
+    {:field-name "tuesday",
+     :required "Required",
+     :details
+     "The tuesday field contains a binary value that indicates whether the service is valid for all Tuesdays."}
+    {:field-name "wednesday",
+     :required "Required",
+     :details
+     "The wednesday field contains a binary value that indicates whether the service is valid for all Wednesdays."}
+    {:field-name "thursday",
+     :required "Required",
+     :details
+     "The thursday field contains a binary value that indicates whether the service is valid for all Thursdays."}
+    {:field-name "friday",
+     :required "Required",
+     :details
+     "The friday field contains a binary value that indicates whether the service is valid for all Fridays."}
+    {:field-name "saturday",
+     :required "Required",
+     :details
+     "The saturday field contains a binary value that indicates whether the service is valid for all Saturdays."}
+    {:field-name "sunday",
+     :required "Required",
+     :details
+     "The sunday field contains a binary value that indicates whether the service is valid for all Sundays."}
+    {:field-name "start_date",
+     :required "Required",
+     :details
+     "The start_date field contains the start date for the service.  The start_date field's value should be in YYYYMMDD format."}
+    {:field-name "end_date",
+     :required "Required",
+     :details
+     "The end_date field contains the end date for the service. This date is included in the service interval.  The end_date field's value should be in YYYYMMDD format."})}
+  {:filename "calendar_dates.txt",
+   :fields
+   ({:field-name "service_id",
+     :required "Required",
+     :details
+     "The service_id contains an ID that uniquely identifies a set of dates when a service exception is available for one or more routes. Each (service_id, date) pair can only appear once in calendar_dates.txt. If the a service_id value appears in both the calendar.txt and calendar_dates.txt files, the information in calendar_dates.txt modifies the service information specified in calendar.txt. This field is referenced by the trips.txt file."}
+    {:field-name "date",
+     :required "Required",
+     :details
+     "The date field specifies a particular date when service availability is different than the norm. You can use the exception_type field to indicate whether service is available on the specified date. The date field's value should be in YYYYMMDD format."}
+    {:field-name "exception_type",
+     :required "Required",
+     :details
+     "The exception_type indicates whether service is available on the date specified in the date field.",
+     :values
+     ("*  A value of 1 indicates that service has been added for the specified date."
+      "* A value of 2 indicates that service has been removed for the specified date."
+      "For example, suppose a route has one set of trips available on holidays and another set of trips available on all other days. You could have one service_id that corresponds to the regular service schedule and another service_id that corresponds to the holiday schedule. For a particular holiday, you would use the calendar_dates.txt file to add the holiday to the holiday service_id and to remove the holiday from the regular service_id schedule.")})}
+  {:filename "fare_attributes.txt",
+   :fields
+   ({:field-name "fare_id",
+     :required "Required",
+     :details
+     "The fare_id field contains an ID that uniquely identifies a fare class. The fare_id is dataset unique."}
+    {:field-name "price",
+     :required "Required",
+     :details
+     "The price field contains the fare price, in the unit specified by currency_type."}
+    {:field-name "currency_type",
+     :required "Required",
+     :details
+     "The currency_type field defines the currency used to pay the fare. Please use the ISO 4217 alphabetical currency codes which can be found at the following URL: http://en.wikipedia.org/wiki/ISO_4217."}
+    {:field-name "payment_method",
+     :required "Required",
+     :details
+     "The payment_method field indicates when the fare must be paid. Valid values for this field are:",
+     :values
+     ({:description "Fare is paid on board.", :value "0"}
+      {:description "Fare must be paid before boarding.", :value "1"})}
+    {:field-name "transfers",
+     :required "Required",
+     :details
+     "The transfers field specifies the number of transfers permitted on this fare. Valid values for this field are:",
+     :values
+     ({:description "No transfers permitted on this fare.", :value "0"}
+      {:description "Passenger may transfer once.", :value "1"}
+      {:description "Passenger may transfer twice.", :value "2"}
+      "* (empty) - If this field is empty, unlimited transfers are permitted.")}
+    {:field-name "agency_id",
+     :required "Optional",
+     :details
+     "Required for feeds with multiple agencies defined in the agency.txt file. Each fare attribute must specify an agency_id value to indicate which agency the fare applies to."}
+    {:field-name "transfer_duration",
+     :required "Optional",
+     :details
+     "The transfer_duration field specifies the length of time in seconds before a transfer expires.  When used with a transfers value of 0, the transfer_duration field indicates how long a ticket is valid for a fare where no transfers are allowed. Unless you intend to use this field to indicate ticket validity, transfer_duration should be omitted or empty when transfers is set to 0."})}
+  {:filename "fare_rules.txt",
+   :fields
+   ({:field-name "fare_id",
+     :required "Required",
+     :details
+     "The fare_id field contains an ID that uniquely identifies a fare class. This value is referenced from the fare_attributes.txt file."}
+    {:field-name "route_id",
+     :required "Optional",
+     :details
+     "The route_id field associates the fare ID with a route. Route IDs are referenced from the routes.txt file. If you have several routes with the same fare attributes, create a row in fare_rules.txt for each route."}
+    {:field-name "origin_id",
+     :required "Optional",
+     :details
+     "The origin_id field associates the fare ID with an origin zone ID. Zone IDs are referenced from the stops.txt file. If you have several origin IDs with the same fare attributes, create a row in fare_rules.txt for each origin ID."}
+    {:field-name "destination_id",
+     :required "Optional",
+     :details
+     "The destination_id field associates the fare ID with a destination zone ID. Zone IDs are referenced from the stops.txt file. If you have several destination IDs with the same fare attributes, create a row in fare_rules.txt for each destination ID."}
+    {:field-name "contains_id",
+     :required "Optional",
+     :details
+     "The contains_id field associates the fare ID with a zone ID, referenced from the stops.txt file. The fare ID is then associated with itineraries that pass through every contains_id zone."})}
+  {:filename "shapes.txt",
+   :fields
+   ({:field-name "shape_id",
+     :required "Required",
+     :details
+     "The shape_id field contains an ID that uniquely identifies a shape."}
+    {:field-name "shape_pt_lat",
+     :required "Required",
+     :details
+     "The shape_pt_lat field associates a shape point's latitude with a shape ID. The field value must be a valid WGS 84 latitude. Each row in shapes.txt represents a shape point in your shape definition."}
+    {:field-name "shape_pt_lon",
+     :required "Required",
+     :details
+     "The shape_pt_lon field associates a shape point's longitude with a shape ID. The field value must be a valid WGS 84 longitude value from -180 to 180. Each row in shapes.txt represents a shape point in your shape definition."}
+    {:field-name "shape_pt_sequence",
+     :required "Required",
+     :details
+     "The shape_pt_sequence field associates the latitude and longitude of a shape point with its sequence order along the shape. The values for shape_pt_sequence must be non-negative integers, and they must increase along the trip."}
+    {:field-name "shape_dist_traveled",
+     :required "Optional",
+     :details
+     "When used in the shapes.txt file, the shape_dist_traveled field positions a shape point as a distance traveled along a shape from the first shape point. The shape_dist_traveled field represents a real distance traveled along the route in units such as feet or kilometers. This information allows the trip planner to determine how much of the shape to draw when showing part of a trip on the map. The values used for shape_dist_traveled must increase along with shape_pt_sequence: they cannot be used to show reverse travel along a route."})}
+  {:filename "frequencies.txt",
+   :fields
+   ({:field-name "trip_id",
+     :required "Required",
+     :details
+     "The trip_id contains an ID that identifies a trip on which the specified frequency of service applies. Trip IDs are referenced from the trips.txt file."}
+    {:field-name "start_time",
+     :required "Required",
+     :details
+     "The start_time field specifies the time at which the first vehicle departs from the first stop of the trip with the specified frequency. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. E.g. 25:35:00."}
+    {:field-name "end_time",
+     :required "Required",
+     :details
+     "The end_time field indicates the time at which service changes to a different frequency (or ceases) at the first stop in the trip. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. E.g. 25:35:00."}
+    {:field-name "headway_secs",
+     :required "Required",
+     :details
+     "The headway_secs field indicates the time between departures from the same stop (headway) for this trip type, during the time interval specified by start_time and end_time. The headway value must be entered in seconds."}
+    {:field-name "exact_times",
+     :required "Optional",
+     :details
+     "The exact_times field determines if frequency-based trips should be exactly scheduled based on the specified headway information. Valid values for this field are:",
+     :values
+     ("* 0 or (empty) - Frequency-based trips are not exactly scheduled. This is the default behavior."
+      {:description
+       "Frequency-based trips are exactly scheduled. For a frequencies.txt row, trips are scheduled starting with trip_start_time = start_time + x * headway_secs for all x in (0, 1, 2, ...) where trip_start_time < end_time.",
+       :value "1"}
+      "The value of exact_times must be the same for all frequencies.txt rows with the same trip_id. If exact_times is 1 and a frequencies.txt row has a start_time equal to end_time, no trip must be scheduled. When exact_times is 1, care must be taken to choose an end_time value that is greater than the last desired trip start time but less than the last desired trip start time + headway_secs.")})}
+  {:filename "transfers.txt",
+   :fields
+   ({:field-name "from_stop_id",
+     :required "Required",
+     :details
+     "The from_stop_id field contains a stop ID that identifies a stop or station where a connection between routes begins. Stop IDs are referenced from the stops.txt file. If the stop ID refers to a station that contains multiple stops, this transfer rule applies to all stops in that station."}
+    {:field-name "to_stop_id",
+     :required "Required",
+     :details
+     "The to_stop_id field contains a stop ID that identifies a stop or station where a connection between routes ends. Stop IDs are referenced from the stops.txt file. If the stop ID refers to a station that contains multiple stops, this transfer rule applies to all stops in that station."}
+    {:field-name "transfer_type",
+     :required "Required",
+     :details
+     "The transfer_type field specifies the type of connection for the specified (from_stop_id, to_stop_id) pair. Valid values for this field are:",
+     :values
+     ("* 0 or (empty) - This is a recommended transfer point between routes."
+      {:description
+       "This is a timed transfer point between two routes. The departing vehicle is expected to wait for the arriving one, with sufficient time for a passenger to transfer between routes.",
+       :value "1"}
+      {:description
+       "This transfer requires a minimum amount of time between arrival and departure to ensure a connection. The time required to transfer is specified by min_transfer_time.",
+       :value "2"}
+      {:description
+       "Transfers are not possible between routes at this location.",
+       :value "3"})}
+    {:field-name "min_transfer_time",
+     :required "Optional",
+     :details
+     "When a connection between routes requires an amount of time between arrival and departure (transfer_type=2), the min_transfer_time field defines the amount of time that must be available in an itinerary to permit a transfer between routes at these stops. The min_transfer_time must be sufficient to permit a typical rider to move between the two stops, including buffer time to allow for schedule variance on each route."})}
+  {:filename "feed_info.txt",
+   :fields
+   ({:field-name "feed_publisher_name",
+     :required "Required",
+     :details
+     "The feed_publisher_name field contains the full name of the organization that publishes the feed. (This may be the same as one of the agency_name values in agency.txt.) GTFS-consuming applications can display this name when giving attribution for a particular feed's data."}
+    {:field-name "feed_publisher_url",
+     :required "Required",
+     :details
+     "The feed_publisher_url field contains the URL of the feed publishing organization's website. (This may be the same as one of the agency_url values in agency.txt.) The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
+    {:field-name "feed_lang",
+     :required "Required",
+     :details
+     "The feed_lang field contains a IETF BCP 47 language code specifying the default language used for the text in this feed. This setting helps GTFS consumers choose capitalization rules and other language-specific settings for the feed. For an introduction to IETF BCP 47, please refer to http://www.rfc-editor.org/rfc/bcp/bcp47.txt and http://www.w3.org/International/articles/language-tags/."}
+    {:field-name "feed_start_date",
+     :required "Optional",
+     :details
+     "The feed provides complete and reliable schedule information for service in the period from the beginning of the feed_start_date day to the end of the feed_end_date day. Both days are given as dates in YYYYMMDD format as for calendar.txt, or left empty if unavailable. The feed_end_date date must not precede the feed_start_date date if both are given. Feed providers are encouraged to give schedule data outside this period to advise of likely future service, but feed consumers should treat it mindful of its non-authoritative status. If feed_start_date or feed_end_date extend beyond the active calendar dates defined in calendar.txt and calendar_dates.txt, the feed is making an explicit assertion that there is no service for dates within the feed_start_date or feed_end_date range but not included in the active calendar dates."}
+    {:field-name "feed_end_date",
+     :required "Optional",
+     :details "(see above)"}
+    {:field-name "feed_version",
+     :required "Optional",
+     :details
+     "The feed publisher can specify a string here that indicates the current version of their GTFS feed. GTFS-consuming applications can display this value to help feed publishers determine whether the latest version of their feed has been incorporated."})})}

--- a/resources/gtfs/reference.edn
+++ b/resources/gtfs/reference.edn
@@ -5,127 +5,129 @@
                :unique   " The field contains a value that maps to a single distinct entity within the column. For example, if a route is assigned the ID 1A, then no other route may use that route ID. However, you may assign the ID 1A to a location because locations are a different type of entity than routes"}
  :feed-files
  ({:filename "agency.txt",
-   :required "Required",
+   :required true,
    :defines
    "One or more transit agencies that provide the data in this feed."}
   {:filename "stops.txt",
-   :required "Required",
+   :required true,
    :defines
    "Individual locations where vehicles pick up or drop off passengers."}
   {:filename "routes.txt",
-   :required "Required",
+   :required true,
    :defines
    "Transit routes. A route is a group of trips that are displayed to riders as a single service."}
   {:filename "trips.txt",
-   :required "Required",
+   :required true,
    :defines
    "Trips for each route. A trip is a sequence of two or more stops that occurs at specific time."}
   {:filename "stop_times.txt",
-   :required "Required",
+   :required true,
    :defines
    "Times that a vehicle arrives at and departs from individual stops for each trip."}
   {:filename "calendar.txt",
-   :required "Required",
+   :required true,
    :defines
    "Dates for service IDs using a weekly schedule. Specify when service starts and ends, as well as days of the week where service is available."}
   {:filename "calendar_dates.txt",
-   :required "Optional",
+   :required false,
    :defines
    "Exceptions for the service IDs defined in the calendar.txt file. If calendar.txt includes ALL dates of service, this file may be specified instead of calendar.txt."}
   {:filename "fare_attributes.txt",
-   :required "Optional",
+   :required false,
    :defines "Fare information for a transit organization's routes."}
   {:filename "fare_rules.txt",
-   :required "Optional",
+   :required false,
    :defines
    "Rules for applying fare information for a transit organization's routes."}
   {:filename "shapes.txt",
-   :required "Optional",
+   :required false,
    :defines
    "Rules for drawing lines on a map to represent a transit organization's routes."}
   {:filename "frequencies.txt",
-   :required "Optional",
+   :required false,
    :defines
    "Headway (time between trips) for routes with variable frequency of service."}
   {:filename "transfers.txt",
-   :required "Optional",
+   :required false,
    :defines
    "Rules for making connections at transfer points between routes."}
   {:filename "feed_info.txt",
-   :required "Optional",
+   :required false,
    :defines
    "Additional information about the feed itself, including publisher, version, and expiration information."}),
  :field-definitions
  ({:filename "agency.txt",
    :fields
    ({:field-name "agency_id",
-     :required "Optional",
+     :required false,
      :details
-     "The agency_id field is an ID that uniquely identifies a transit agency. A transit feed may represent data from more than one agency. The agency_id is dataset unique. This field is optional for transit feeds that only contain data for a single agency."}
+     "The agency_id field is an ID that uniquely identifies a transit agency. A transit feed may represent data from more than one agency. The agency_id is dataset unique. This field is optional for transit feeds that only contain data for a single agency.",
+     :unique true}
     {:field-name "agency_name",
-     :required "Required",
+     :required true,
      :details
      "The agency_name field contains the full name of the transit agency. Google Maps will display this name."}
     {:field-name "agency_url",
-     :required "Required",
+     :required true,
      :details
      "The agency_url field contains the URL of the transit agency. The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
     {:field-name "agency_timezone",
-     :required "Required",
+     :required true,
      :details
      "The agency_timezone field contains the timezone where the transit agency is located. Timezone names never contain the space character but may contain an underscore. Please refer to http://en.wikipedia.org/wiki/List_of_tz_zones for a list of valid values. If multiple agencies are specified in the feed, each must have the same agency_timezone."}
     {:field-name "agency_lang",
-     :required "Optional",
+     :required false,
      :details
      "The agency_lang field contains a two-letter ISO 639-1 code for the primary language used by this transit agency. The language code is case-insensitive (both en and EN are accepted). This setting defines capitalization rules and other language-specific settings for all text contained in this transit agency's feed. Please refer to http://www.loc.gov/standards/iso639-2/php/code_list.php for a list of valid values."}
     {:field-name "agency_phone",
-     :required "Optional",
+     :required false,
      :details
      "The agency_phone field contains a single voice telephone number for the specified agency. This field is a string value that presents the telephone number as typical for the agency's service area. It can and should contain punctuation marks to group the digits of the number. Dialable text (for example, TriMet's \"503-238-RIDE\") is permitted, but the field must not contain any other descriptive text."}
     {:field-name "agency_fare_url",
-     :required "Optional",
+     :required false,
      :details
      "The agency_fare_url specifies the URL of a web page that allows a rider to purchase tickets or other fare instruments for that agency online. The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
     {:field-name "agency_email",
-     :required "Optional",
+     :required false,
      :details
      "Contains a single valid email address actively monitored by the agency’s customer service department. This email address will be considered a direct contact point where transit riders can reach a customer service representative at the agency."})}
   {:filename "stops.txt",
    :fields
    ({:field-name "stop_id",
-     :required "Required",
+     :required true,
      :details
-     "The stop_id field contains an ID that uniquely identifies a stop, station, or station entrance. Multiple routes may use the same stop. The stop_id is used by systems as an internal identifier of this record (e.g., primary key in database), and therefore the stop_id must be dataset unique."}
+     "The stop_id field contains an ID that uniquely identifies a stop, station, or station entrance. Multiple routes may use the same stop. The stop_id is used by systems as an internal identifier of this record (e.g., primary key in database), and therefore the stop_id must be dataset unique.",
+     :unique true}
     {:field-name "stop_code",
-     :required "Optional",
+     :required false,
      :details
      "The stop_code field contains short text or a number that uniquely identifies the stop for passengers. Stop codes are often used in phone-based transit information systems or printed on stop signage to make it easier for riders to get a stop schedule or real-time arrival information for a particular stop.  The stop_code field contains short text or a number that uniquely identifies the stop for passengers. The stop_code can be the same as stop_id if it is passenger-facing. This field should be left blank for stops without a code presented to passengers."}
     {:field-name "stop_name",
-     :required "Required",
+     :required true,
      :details
      "The stop_name field contains the name of a stop, station, or station entrance. Please use a name that people will understand in the local and tourist vernacular."}
     {:field-name "stop_desc",
-     :required "Optional",
+     :required false,
      :details
      "The stop_desc field contains a description of a stop. Please provide useful, quality information. Do not simply duplicate the name of the stop."}
     {:field-name "stop_lat",
-     :required "Required",
+     :required true,
      :details
      "The stop_lat field contains the latitude of a stop, station, or station entrance. The field value must be a valid WGS 84 latitude."}
     {:field-name "stop_lon",
-     :required "Required",
+     :required true,
      :details
      "The stop_lon field contains the longitude of a stop, station, or station entrance. The field value must be a valid WGS 84 longitude value from -180 to 180."}
     {:field-name "zone_id",
-     :required "Optional",
+     :required false,
      :details
      "The zone_id field defines the fare zone for a stop ID. Zone IDs are required if you want to provide fare information using fare_rules.txt. If this stop ID represents a station, the zone ID is ignored."}
     {:field-name "stop_url",
-     :required "Optional",
+     :required false,
      :details
      "The stop_url field contains the URL of a web page about a particular stop. This should be different from the agency_url and the route_url fields.  The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
     {:field-name "location_type",
-     :required "Optional",
+     :required false,
      :details
      "The location_type field identifies whether this stop ID represents a stop, station, or station entrance. If no location type is specified, or the location_type is blank, stop IDs are treated as stops. Stations may have different properties from stops when they are represented on a map or used in trip planning.  The location type field can have the following values:",
      :values
@@ -137,15 +139,15 @@
        "Station Entrance/Exit. A location where passengers can enter or exit a station from the street. The stop entry must also specify a parent_station value referencing the stop ID of the parent station for the entrance.",
        :value "2"})}
     {:field-name "parent_station",
-     :required "Optional",
+     :required false,
      :details
      "For stops that are physically located inside stations, the parent_station field identifies the station associated with the stop. To use this field, stops.txt must also contain a row where this stop ID is assigned location type=1."}
     {:field-name "stop_timezone",
-     :required "Optional",
+     :required false,
      :details
      "The stop_timezone field contains the timezone in which this stop, station, or station entrance is located. Please refer to Wikipedia List of Timezones for a list of valid values. If omitted, the stop should be assumed to be located in the timezone specified by agency_timezone in agency.txt.   When a stop has a parent station, the stop is considered to be in the timezone specified by the parent station's stop_timezone value. If the parent has no stop_timezone value, the stops that belong to that station are assumed to be in the timezone specified by agency_timezone, even if the stops have their own stop_timezone values. In other words, if a given stop has a parent_station value, any stop_timezone value specified for that stop must be ignored.  Even if stop_timezone values are provided in stops.txt, the times in stop_times.txt should continue to be specified as time since midnight in the timezone specified by agency_timezone in agency.txt. This ensures that the time values in a trip always increase over the course of a trip, regardless of which timezones the trip crosses."}
     {:field-name "wheelchair_boarding",
-     :required "Optional",
+     :required false,
      :details
      "The wheelchair_boarding field identifies whether wheelchair boardings are possible from the specified stop, station, or station entrance. The field can have the following values:",
      :values
@@ -174,27 +176,28 @@
   {:filename "routes.txt",
    :fields
    ({:field-name "route_id",
-     :required "Required",
+     :required true,
      :details
-     "The route_id field contains an ID that uniquely identifies a route. The route_id is dataset unique."}
+     "The route_id field contains an ID that uniquely identifies a route. The route_id is dataset unique.",
+     :unique true}
     {:field-name "agency_id",
-     :required "Optional",
+     :required false,
      :details
      "The agency_id field defines an agency for the specified route. This value is referenced from the agency.txt file. Use this field when you are providing data for routes from more than one agency."}
     {:field-name "route_short_name",
-     :required "Required",
+     :required true,
      :details
      "The route_short_name contains the short name of a route. This will often be a short, abstract identifier like \"32\", \"100X\", or \"Green\" that riders use to identify a route, but which doesn't give any indication of what places the route serves. At least one of route_short_name or route_long_name must be specified, or potentially both if appropriate. If the route does not have a short name, please specify a route_long_name and use an empty string as the value for this field."}
     {:field-name "route_long_name",
-     :required "Required",
+     :required true,
      :details
      "The route_long_name contains the full name of a route. This name is generally more descriptive than the route_short_name and will often include the route's destination or stop. At least one of route_short_name or route_long_name must be specified, or potentially both if appropriate. If the route does not have a long name, please specify a route_short_name and use an empty string as the value for this field."}
     {:field-name "route_desc",
-     :required "Optional",
+     :required false,
      :details
      "The route_desc field contains a description of a route. Please provide useful, quality information. Do not simply duplicate the name of the route. For example, \"A trains operate between Inwood-207 St, Manhattan and Far Rockaway-Mott Avenue, Queens at all times. Also from about 6AM until about midnight, additional A trains operate between Inwood-207 St and Lefferts Boulevard (trains typically alternate between Lefferts Blvd and Far Rockaway).\""}
     {:field-name "route_type",
-     :required "Required",
+     :required true,
      :details
      "The route_type field describes the type of transportation used on a route. Valid values for this field are:",
      :values
@@ -223,45 +226,46 @@
        "Funicular. Any rail system designed for steep inclines.",
        :value "7"})}
     {:field-name "route_url",
-     :required "Optional",
+     :required false,
      :details
      "The route_url field contains the URL of a web page about that particular route. This should be different from the agency_url.  The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
     {:field-name "route_color",
-     :required "Optional",
+     :required false,
      :details
      "In systems that have colors assigned to routes, the route_color field defines a color that corresponds to a route. The color must be provided as a six-character hexadecimal number, for example, 00FFFF. If no color is specified, the default route color is white (FFFFFF).  The color difference between route_color and route_text_color should provide sufficient contrast when viewed on a black and white screen. The W3C Techniques for Accessibility Evaluation And Repair Tools document offers a useful algorithm for evaluating color contrast. There are also helpful online tools for choosing contrasting colors, including the snook.ca Color Contrast Check application."}
     {:field-name "route_text_color",
-     :required "Optional",
+     :required false,
      :details
      "The route_text_color field can be used to specify a legible color to use for text drawn against a background of route_color. The color must be provided as a six-character hexadecimal number, for example, FFD700. If no color is specified, the default text color is black (000000).  The color difference between route_color and route_text_color should provide sufficient contrast when viewed on a black and white screen."}
     {:field-name "route_sort_order",
-     :required "Optional",
+     :required false,
      :details
      "The route_sort_order field can be used to order the routes in a way which is ideal for presentation to customers. It must be a non-negative integer. Routes with smaller route_sort_order values should be displayed before routes with larger route_sort_order values."})}
   {:filename "trips.txt",
    :fields
    ({:field-name "route_id",
-     :required "Required",
+     :required true,
      :details
      "The route_id field contains an ID that uniquely identifies a route. This value is referenced from the routes.txt file."}
     {:field-name "service_id",
-     :required "Required",
+     :required true,
      :details
      "The service_id contains an ID that uniquely identifies a set of dates when service is available for one or more routes. This value is referenced from the calendar.txt or calendar_dates.txt file."}
     {:field-name "trip_id",
-     :required "Required",
+     :required true,
      :details
-     "The trip_id field contains an ID that identifies a trip. The trip_id is dataset unique."}
+     "The trip_id field contains an ID that identifies a trip. The trip_id is dataset unique.",
+     :unique true}
     {:field-name "trip_headsign",
-     :required "Optional",
+     :required false,
      :details
      "The trip_headsign field contains the text that appears on a sign that identifies the trip's destination to passengers. Use this field to distinguish between different patterns of service in the same route. If the headsign changes during a trip, you can override the trip_headsign by specifying values for the stop_headsign field in stop_times.txt."}
     {:field-name "trip_short_name",
-     :required "Optional",
+     :required false,
      :details
      "The trip_short_name field contains the text that appears in schedules and sign boards to identify the trip to passengers, for example, to identify train numbers for commuter rail trips. If riders do not commonly rely on trip names, please leave this field blank.  A trip_short_name value, if provided, should uniquely identify a trip within a service day; it should not be used for destination names or limited/express designations."}
     {:field-name "direction_id",
-     :required "Optional",
+     :required false,
      :details
      "The direction_id field contains a binary value that indicates the direction of travel for a trip. Use this field to distinguish between bi-directional trips with the same route_id. This field is not used in routing; it provides a way to separate trips by direction when publishing time tables. You can specify names for each direction with the trip_headsign field.",
      :values
@@ -275,15 +279,15 @@
       "* 1234,...,Airport,0"
       "* 1505,...,Downtown,1")}
     {:field-name "block_id",
-     :required "Optional",
+     :required false,
      :details
      "The block_id field identifies the block to which the trip belongs. A block consists of a single trip or many sequential trips made using the same vehicle, defined by shared service day and block_id. A block_id can have trips with different service days, making distinct blocks. (See example below)"}
     {:field-name "shape_id",
-     :required "Optional",
+     :required false,
      :details
      "The shape_id field contains an ID that defines a shape for the trip. This value is referenced from the shapes.txt file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip."}
     {:field-name "wheelchair_accessible",
-     :required "Optional",
+     :required false,
      :details
      "* 0 (or empty) - indicates that there is no accessibility information for the trip",
      :values
@@ -294,7 +298,7 @@
        "indicates that no riders in wheelchairs can be accommodated on this trip",
        :value "2"})}
     {:field-name "bikes_allowed",
-     :required "Optional",
+     :required false,
      :details
      "0 (or empty) - indicates that there is no bike information for the trip",
      :values
@@ -307,31 +311,31 @@
   {:filename "stop_times.txt",
    :fields
    ({:field-name "trip_id",
-     :required "Required",
+     :required true,
      :details
      "The trip_id field contains an ID that identifies a trip. This value is referenced from the trips.txt file."}
     {:field-name "arrival_time",
-     :required "Required",
+     :required true,
      :details
      "The arrival_time specifies the arrival time at a specific stop for a specific trip on a route. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. If you don't have separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time.Scheduled stops where the vehicle strictly adheres to the specified arrival and departure times are timepoints. For example, if a transit vehicle arrives at a stop before the scheduled departure time, it will hold until the departure time. If this stop is not a timepoint, use either an empty string value for the arrival_time field or provide an interpolated time. Further, indicate that interpolated times are provided via the timepoint field with a value of zero. If interpolated times are indicated with timepoint=0, then time points must be indicated with a value of 1 for the timepoint field. Provide arrival times for all stops that are time points.An arrival time must be specified for the first and the last stop in a trip. Times must be eight digits in HH:MM:SS format (H:MM:SS is also accepted, if the hour begins with 0). Do not pad times with spaces. The following columns list stop times for a trip and the proper way to express those times in the arrival_time field:"}
     {:field-name "departure_time",
-     :required "Required",
+     :required true,
      :details
      "The departure_time specifies the departure time from a specific stop for a specific trip on a route. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. If you don't have separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time.Scheduled stops where the vehicle strictly adheres to the specified arrival and departure times are timepoints. For example, if a transit vehicle arrives at a stop before the scheduled departure time, it will hold until the departure time. If this stop is not a timepoint, use either an empty string value for the departure_time field or provide an interpolated time (further, indicate that interpolated times are provided via the timepoint field with a value of zero). If interpolated times are indicated with timepoint=0, then time points must be indicated with a value of 1 for the timepoint field. Provide departure times for all stops that are time points.A departure time must be specified for the first and the last stop in a trip even if the vehicle does not allow boarding at the last stop.  Times must be eight digits in HH:MM:SS format (H:MM:SS is also accepted, if the hour begins with 0). Do not pad times with spaces. The following columns list stop times for a trip and the proper way to express those times in the departure_time field:"}
     {:field-name "stop_id",
-     :required "Required",
+     :required true,
      :details
      "The stop_id field contains an ID that uniquely identifies a stop. Multiple routes may use the same stop. The stop_id is referenced from the stops.txt file. If location_type is used in stops.txt, all stops referenced in stop_times.txt must have location_type of 0.  Where possible, stop_id values should remain consistent between feed updates. In other words, stop A with stop_id 1 should have stop_id 1 in all subsequent data updates. If a stop is not a time point, enter blank values for arrival_time and departure_time."}
     {:field-name "stop_sequence",
-     :required "Required",
+     :required true,
      :details
      "The stop_sequence field identifies the order of the stops for a particular trip. The values for stop_sequence must be non-negative integers, and they must increase along the trip.  For example, the first stop on the trip could have a stop_sequence of 1, the second stop on the trip could have a stop_sequence of 23, the third stop could have a stop_sequence of 40, and so on."}
     {:field-name "stop_headsign",
-     :required "Optional",
+     :required false,
      :details
      "The stop_headsign field contains the text that appears on a sign that identifies the trip's destination to passengers. Use this field to override the default trip_headsign when the headsign changes between stops. If this headsign is associated with an entire trip, use trip_headsign instead."}
     {:field-name "pickup_type",
-     :required "Optional",
+     :required false,
      :details
      "The pickup_type field indicates whether passengers are picked up at a stop as part of the normal schedule or whether a pickup at the stop is not available. This field also allows the transit agency to indicate that passengers must call the agency or notify the driver to arrange a pickup at a particular stop. Valid values for this field are:",
      :values
@@ -342,7 +346,7 @@
        :value "3"}
       "The default value for this field is 0.")}
     {:field-name "drop_off_type",
-     :required "Optional",
+     :required false,
      :details
      "The drop_off_type field indicates whether passengers are dropped off at a stop as part of the normal schedule or whether a drop off at the stop is not available. This field also allows the transit agency to indicate that passengers must call the agency or notify the driver to arrange a drop off at a particular stop. Valid values for this field are:",
      :values
@@ -354,11 +358,11 @@
        :value "3"}
       "The default value for this field is 0.")}
     {:field-name "shape_dist_traveled",
-     :required "Optional",
+     :required false,
      :details
      "When used in the stop_times.txt file, the shape_dist_traveled field positions a stop as a distance from the first shape point. The shape_dist_traveled field represents a real distance traveled along the route in units such as feet or kilometers. For example, if a bus travels a distance of 5.25 kilometers from the start of the shape to the stop, the shape_dist_traveled for the stop ID would be entered as \"5.25\". This information allows the trip planner to determine how much of the shape to draw when showing part of a trip on the map. The values used for shape_dist_traveled must increase along with stop_sequence: they cannot be used to show reverse travel along a route.  The units used for shape_dist_traveled in the stop_times.txt file must match the units that are used for this field in the shapes.txt file."}
     {:field-name "timepoint",
-     :required "Optional",
+     :required false,
      :details
      "The timepoint field can be used to indicate if the specified arrival and departure times for a stop are strictly adhered to by the transit vehicle or if they are instead approximate and/or interpolated times. The field allows a GTFS producer to provide interpolated stop times that potentially incorporate local knowledge, but still indicate if the times are approximate. For stop-time entries with specified arrival and departure times, valid values for this field are:",
      :values
@@ -369,57 +373,58 @@
   {:filename "calendar.txt",
    :fields
    ({:field-name "service_id",
-     :required "Required",
+     :required true,
      :details
-     "The service_id contains an ID that uniquely identifies a set of dates when service is available for one or more routes. Each service_id value can appear at most once in a calendar.txt file. This value is dataset unique. It is referenced by the trips.txt file."}
+     "The service_id contains an ID that uniquely identifies a set of dates when service is available for one or more routes. Each service_id value can appear at most once in a calendar.txt file. This value is dataset unique. It is referenced by the trips.txt file.",
+     :unique true}
     {:field-name "monday",
-     :required "Required",
+     :required true,
      :details
      "The monday field contains a binary value that indicates whether the service is valid for all Mondays."}
     {:field-name "tuesday",
-     :required "Required",
+     :required true,
      :details
      "The tuesday field contains a binary value that indicates whether the service is valid for all Tuesdays."}
     {:field-name "wednesday",
-     :required "Required",
+     :required true,
      :details
      "The wednesday field contains a binary value that indicates whether the service is valid for all Wednesdays."}
     {:field-name "thursday",
-     :required "Required",
+     :required true,
      :details
      "The thursday field contains a binary value that indicates whether the service is valid for all Thursdays."}
     {:field-name "friday",
-     :required "Required",
+     :required true,
      :details
      "The friday field contains a binary value that indicates whether the service is valid for all Fridays."}
     {:field-name "saturday",
-     :required "Required",
+     :required true,
      :details
      "The saturday field contains a binary value that indicates whether the service is valid for all Saturdays."}
     {:field-name "sunday",
-     :required "Required",
+     :required true,
      :details
      "The sunday field contains a binary value that indicates whether the service is valid for all Sundays."}
     {:field-name "start_date",
-     :required "Required",
+     :required true,
      :details
      "The start_date field contains the start date for the service.  The start_date field's value should be in YYYYMMDD format."}
     {:field-name "end_date",
-     :required "Required",
+     :required true,
      :details
      "The end_date field contains the end date for the service. This date is included in the service interval.  The end_date field's value should be in YYYYMMDD format."})}
   {:filename "calendar_dates.txt",
    :fields
    ({:field-name "service_id",
-     :required "Required",
+     :required true,
      :details
      "The service_id contains an ID that uniquely identifies a set of dates when a service exception is available for one or more routes. Each (service_id, date) pair can only appear once in calendar_dates.txt. If the a service_id value appears in both the calendar.txt and calendar_dates.txt files, the information in calendar_dates.txt modifies the service information specified in calendar.txt. This field is referenced by the trips.txt file."}
     {:field-name "date",
-     :required "Required",
+     :required true,
      :details
      "The date field specifies a particular date when service availability is different than the norm. You can use the exception_type field to indicate whether service is available on the specified date. The date field's value should be in YYYYMMDD format."}
     {:field-name "exception_type",
-     :required "Required",
+     :required true,
      :details
      "The exception_type indicates whether service is available on the date specified in the date field.",
      :values
@@ -429,26 +434,27 @@
   {:filename "fare_attributes.txt",
    :fields
    ({:field-name "fare_id",
-     :required "Required",
+     :required true,
      :details
-     "The fare_id field contains an ID that uniquely identifies a fare class. The fare_id is dataset unique."}
+     "The fare_id field contains an ID that uniquely identifies a fare class. The fare_id is dataset unique.",
+     :unique true}
     {:field-name "price",
-     :required "Required",
+     :required true,
      :details
      "The price field contains the fare price, in the unit specified by currency_type."}
     {:field-name "currency_type",
-     :required "Required",
+     :required true,
      :details
      "The currency_type field defines the currency used to pay the fare. Please use the ISO 4217 alphabetical currency codes which can be found at the following URL: http://en.wikipedia.org/wiki/ISO_4217."}
     {:field-name "payment_method",
-     :required "Required",
+     :required true,
      :details
      "The payment_method field indicates when the fare must be paid. Valid values for this field are:",
      :values
      ({:description "Fare is paid on board.", :value "0"}
       {:description "Fare must be paid before boarding.", :value "1"})}
     {:field-name "transfers",
-     :required "Required",
+     :required true,
      :details
      "The transfers field specifies the number of transfers permitted on this fare. Valid values for this field are:",
      :values
@@ -457,77 +463,77 @@
       {:description "Passenger may transfer twice.", :value "2"}
       "* (empty) - If this field is empty, unlimited transfers are permitted.")}
     {:field-name "agency_id",
-     :required "Optional",
+     :required false,
      :details
      "Required for feeds with multiple agencies defined in the agency.txt file. Each fare attribute must specify an agency_id value to indicate which agency the fare applies to."}
     {:field-name "transfer_duration",
-     :required "Optional",
+     :required false,
      :details
      "The transfer_duration field specifies the length of time in seconds before a transfer expires.  When used with a transfers value of 0, the transfer_duration field indicates how long a ticket is valid for a fare where no transfers are allowed. Unless you intend to use this field to indicate ticket validity, transfer_duration should be omitted or empty when transfers is set to 0."})}
   {:filename "fare_rules.txt",
    :fields
    ({:field-name "fare_id",
-     :required "Required",
+     :required true,
      :details
      "The fare_id field contains an ID that uniquely identifies a fare class. This value is referenced from the fare_attributes.txt file."}
     {:field-name "route_id",
-     :required "Optional",
+     :required false,
      :details
      "The route_id field associates the fare ID with a route. Route IDs are referenced from the routes.txt file. If you have several routes with the same fare attributes, create a row in fare_rules.txt for each route."}
     {:field-name "origin_id",
-     :required "Optional",
+     :required false,
      :details
      "The origin_id field associates the fare ID with an origin zone ID. Zone IDs are referenced from the stops.txt file. If you have several origin IDs with the same fare attributes, create a row in fare_rules.txt for each origin ID."}
     {:field-name "destination_id",
-     :required "Optional",
+     :required false,
      :details
      "The destination_id field associates the fare ID with a destination zone ID. Zone IDs are referenced from the stops.txt file. If you have several destination IDs with the same fare attributes, create a row in fare_rules.txt for each destination ID."}
     {:field-name "contains_id",
-     :required "Optional",
+     :required false,
      :details
      "The contains_id field associates the fare ID with a zone ID, referenced from the stops.txt file. The fare ID is then associated with itineraries that pass through every contains_id zone."})}
   {:filename "shapes.txt",
    :fields
    ({:field-name "shape_id",
-     :required "Required",
+     :required true,
      :details
      "The shape_id field contains an ID that uniquely identifies a shape."}
     {:field-name "shape_pt_lat",
-     :required "Required",
+     :required true,
      :details
      "The shape_pt_lat field associates a shape point's latitude with a shape ID. The field value must be a valid WGS 84 latitude. Each row in shapes.txt represents a shape point in your shape definition."}
     {:field-name "shape_pt_lon",
-     :required "Required",
+     :required true,
      :details
      "The shape_pt_lon field associates a shape point's longitude with a shape ID. The field value must be a valid WGS 84 longitude value from -180 to 180. Each row in shapes.txt represents a shape point in your shape definition."}
     {:field-name "shape_pt_sequence",
-     :required "Required",
+     :required true,
      :details
      "The shape_pt_sequence field associates the latitude and longitude of a shape point with its sequence order along the shape. The values for shape_pt_sequence must be non-negative integers, and they must increase along the trip."}
     {:field-name "shape_dist_traveled",
-     :required "Optional",
+     :required false,
      :details
      "When used in the shapes.txt file, the shape_dist_traveled field positions a shape point as a distance traveled along a shape from the first shape point. The shape_dist_traveled field represents a real distance traveled along the route in units such as feet or kilometers. This information allows the trip planner to determine how much of the shape to draw when showing part of a trip on the map. The values used for shape_dist_traveled must increase along with shape_pt_sequence: they cannot be used to show reverse travel along a route."})}
   {:filename "frequencies.txt",
    :fields
    ({:field-name "trip_id",
-     :required "Required",
+     :required true,
      :details
      "The trip_id contains an ID that identifies a trip on which the specified frequency of service applies. Trip IDs are referenced from the trips.txt file."}
     {:field-name "start_time",
-     :required "Required",
+     :required true,
      :details
      "The start_time field specifies the time at which the first vehicle departs from the first stop of the trip with the specified frequency. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. E.g. 25:35:00."}
     {:field-name "end_time",
-     :required "Required",
+     :required true,
      :details
      "The end_time field indicates the time at which service changes to a different frequency (or ceases) at the first stop in the trip. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. E.g. 25:35:00."}
     {:field-name "headway_secs",
-     :required "Required",
+     :required true,
      :details
      "The headway_secs field indicates the time between departures from the same stop (headway) for this trip type, during the time interval specified by start_time and end_time. The headway value must be entered in seconds."}
     {:field-name "exact_times",
-     :required "Optional",
+     :required false,
      :details
      "The exact_times field determines if frequency-based trips should be exactly scheduled based on the specified headway information. Valid values for this field are:",
      :values
@@ -539,15 +545,15 @@
   {:filename "transfers.txt",
    :fields
    ({:field-name "from_stop_id",
-     :required "Required",
+     :required true,
      :details
      "The from_stop_id field contains a stop ID that identifies a stop or station where a connection between routes begins. Stop IDs are referenced from the stops.txt file. If the stop ID refers to a station that contains multiple stops, this transfer rule applies to all stops in that station."}
     {:field-name "to_stop_id",
-     :required "Required",
+     :required true,
      :details
      "The to_stop_id field contains a stop ID that identifies a stop or station where a connection between routes ends. Stop IDs are referenced from the stops.txt file. If the stop ID refers to a station that contains multiple stops, this transfer rule applies to all stops in that station."}
     {:field-name "transfer_type",
-     :required "Required",
+     :required true,
      :details
      "The transfer_type field specifies the type of connection for the specified (from_stop_id, to_stop_id) pair. Valid values for this field are:",
      :values
@@ -562,31 +568,31 @@
        "Transfers are not possible between routes at this location.",
        :value "3"})}
     {:field-name "min_transfer_time",
-     :required "Optional",
+     :required false,
      :details
      "When a connection between routes requires an amount of time between arrival and departure (transfer_type=2), the min_transfer_time field defines the amount of time that must be available in an itinerary to permit a transfer between routes at these stops. The min_transfer_time must be sufficient to permit a typical rider to move between the two stops, including buffer time to allow for schedule variance on each route."})}
   {:filename "feed_info.txt",
    :fields
    ({:field-name "feed_publisher_name",
-     :required "Required",
+     :required true,
      :details
      "The feed_publisher_name field contains the full name of the organization that publishes the feed. (This may be the same as one of the agency_name values in agency.txt.) GTFS-consuming applications can display this name when giving attribution for a particular feed's data."}
     {:field-name "feed_publisher_url",
-     :required "Required",
+     :required true,
      :details
      "The feed_publisher_url field contains the URL of the feed publishing organization's website. (This may be the same as one of the agency_url values in agency.txt.) The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
     {:field-name "feed_lang",
-     :required "Required",
+     :required true,
      :details
      "The feed_lang field contains a IETF BCP 47 language code specifying the default language used for the text in this feed. This setting helps GTFS consumers choose capitalization rules and other language-specific settings for the feed. For an introduction to IETF BCP 47, please refer to http://www.rfc-editor.org/rfc/bcp/bcp47.txt and http://www.w3.org/International/articles/language-tags/."}
     {:field-name "feed_start_date",
-     :required "Optional",
+     :required false,
      :details
      "The feed provides complete and reliable schedule information for service in the period from the beginning of the feed_start_date day to the end of the feed_end_date day. Both days are given as dates in YYYYMMDD format as for calendar.txt, or left empty if unavailable. The feed_end_date date must not precede the feed_start_date date if both are given. Feed providers are encouraged to give schedule data outside this period to advise of likely future service, but feed consumers should treat it mindful of its non-authoritative status. If feed_start_date or feed_end_date extend beyond the active calendar dates defined in calendar.txt and calendar_dates.txt, the feed is making an explicit assertion that there is no service for dates within the feed_start_date or feed_end_date range but not included in the active calendar dates."}
     {:field-name "feed_end_date",
-     :required "Optional",
+     :required false,
      :details "(see above)"}
     {:field-name "feed_version",
-     :required "Optional",
+     :required false,
      :details
      "The feed publisher can specify a string here that indicates the current version of their GTFS feed. GTFS-consuming applications can display this value to help feed publishers determine whether the latest version of their feed has been incorporated."})})}

--- a/src/hiposfer/kamal/gtfs.clj
+++ b/src/hiposfer/kamal/gtfs.clj
@@ -6,7 +6,8 @@
   Useful to avoid monkey patching"
   (:require [clojure.string :as str]
             [markdown2clj.core :as md]
-            [clojure.pprint :as pprint]))
+            [clojure.pprint :as pprint]
+            [clojure.edn :as edn]))
 
 (def url "https://raw.githubusercontent.com/google/transit/master/gtfs/spec/en/reference.md")
 
@@ -63,7 +64,7 @@
   [text]
   (if-let [[_ value description] (re-matches #"\* (\d) - (.*)" text)]
     {:description description
-     :value value}
+     :value (edn/read-string value)}
     text))
 
 (defn- parse-enums

--- a/src/hiposfer/kamal/gtfs.clj
+++ b/src/hiposfer/kamal/gtfs.clj
@@ -1,0 +1,112 @@
+(ns hiposfer.kamal.gtfs
+  "parse the Markdown GTFS spec definition and returns it as Clojure data structures.
+
+  Uses several heuristics to guess how to interpret the data.
+
+  Useful to avoid monkey patching"
+  (:require [clojure.string :as str]
+            [markdown2clj.core :as md]
+            [clojure.pprint :as pprint]))
+
+(def url "https://raw.githubusercontent.com/google/transit/master/gtfs/spec/en/reference.md")
+
+;; NOTE: we purposedly discard the edge case of several nested headers as
+;; it makes this function much more simpler
+(defn sections
+  [md]
+  (let [prev (volatile! (first (:document md)))]
+    (partition-by (fn [v] (if (:heading v)
+                            (vreset! prev v)
+                            (deref prev)))
+                  (:document md))))
+;; (sections content)
+
+(defn zipify
+  [section]
+  (let [table   (some :table-block section)
+        head    (some :table-head table)
+        body    (some :table-body table)
+        headers (->> (tree-seq coll? seq head)
+                     (filter string?)
+                     (map str/lower-case)
+                     (map #(str/replace % " " "-")) ;; otherwise not valid literal keyword
+                     (map keyword))
+        rows    (for [row (map :table-row body)]
+                  (for [cell row]
+                    (->> (tree-seq coll? seq cell)
+                         (filter map?)
+                         (filter :text)
+                         (map :text)
+                         (str/join ""))))]
+    (map #(zipmap %1 %2) (repeat headers) rows)))
+;; example
+;; (feed-files content)
+
+
+(defn- header [section] (-> section first :heading second :text))
+
+(def enum-edge-cases #{"wheelchair_boarding" "direction_id"
+                       "wheelchair_accessible" "timepoint"
+                       "payment_method" "transfers"
+                       "exact_times" "bikes_allowed"})
+
+(defn- enum?
+  [parent field]
+  (and (empty? (:field-name field))
+       (empty? (:required field))
+       (not (empty? (:details field)))
+       (or (str/ends-with? (:field-name parent) "_type")
+           (contains? enum-edge-cases
+                      (:field-name parent)))))
+
+(defn- enum-value
+  [text]
+  (if-let [[_ value description] (re-matches #"\* (\d) - (.*)" text)]
+    {:description description
+     :value value}
+    text))
+
+(defn- parse-enums
+  ([fields]
+   (parse-enums (rest fields) [] (first fields)))
+  ([fields result parent]
+   (cond
+     (enum? parent (first fields))
+     (recur (rest fields)
+            result
+            (update parent :values conj (enum-value (:details (first fields)))))
+
+     (some? (:values parent))
+     (recur (rest fields)
+            (conj result (update parent :values reverse))
+            (first fields))
+
+     (and (empty? fields) (nil? parent)) result
+
+     (empty? fields) (conj result parent)
+
+     :else
+     (recur (rest fields) (conj result parent) (first fields)))))
+
+(defn- parse
+  [raw]
+  (let [content    (md/parse raw)
+        parts      (sections content)
+        feed-files (some #(when (= "Feed Files" (header %)) %) parts)
+        feed-data  (zipify feed-files)
+        files      (filter #(when (str/ends-with? (header %) ".txt") %)
+                           (sections content))
+        files-data (for [file files]
+                     {:filename (header file)
+                      :fields   (->> (zipify file)
+                                     (parse-enums)
+                                     (remove #(and (empty? (:field-name %))
+                                                   (empty? (:required %)))))})]
+    {:feed-files feed-data
+     :field-definitions files-data}))
+
+(defn -main
+  [f out]
+  (spit out (with-out-str (pprint/pprint (parse (slurp f))))))
+
+;(-main url)


### PR DESCRIPTION
Problems:
- different applications, like kamal and hive use the gtfs spec as base, but there is not a single representation of the spec itself.
- The knowledge of the spec is out of band, which means that it is not possible to use it for verification
- It cannot be analyzed by computer tools 
- It cannot be used as documentation for humans as its representation is context dependent. For example: the html docs of the spec cannot be shown in a react native component. The documentation of a single field cannot be dynamically queried and shown to a user.

Solution:
create a single machine and human readable spec reference that is independent of the implementation context

This PR doesnt expose yet the spec to the outside. We can tackle that in another PR together with #207 and with #199 

PS: I created a little script to parse the markdown gtfs reference and create an edn file from it. Although manual changes in the EDN file are not reflected in that script, it serves as a good starting point.