### PR TITLE
Preprocess refactored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: clojure
 jdk:
 - oraclejdk8
 script:
-- lein do clean, compile, check
+- lein do clean, compile, check, eastwood
 # test requires quite some memory so free it afterwards
 - lein trampoline test
-# linter
-- lein eastwood
 notifications:
   email:
     on_success: change

--- a/README.md
+++ b/README.md
@@ -51,22 +51,15 @@ hiposfer.kamal.core=> (hiposfer.kamal.dev/refresh!)
 And then browse to [localhost:3000](http://localhost:3000)
 
 ## OSM Files
-`kamal` consumes Open Street Map (OSM) data files. OSM files are usually very large and
-consume a lot of memory to process, therefore we use a fake `network` during the development.
-The fake `network`'s size can be tuned via the `:network-size` configuration. 
+`kamal` consumes General Transit Feed Specification (GTFS) and Open Street Map files.
 
-Using a fake network can significantly increase your development speed as there is
-no need to reparse the OSM file. You can test your changes on a real OSM file by
-setting `:dev` to `false`.
+`kamal` is very routing oriented, thus we rely on the awesome Overpass-API for
+filtering of Open Street Map data. Check out our `pedestrian` filtering query
+[Here](resources/osm/overpass-api-query.txt). 
 
-`kamal` is very routing oriented, thus no filtering is performed when reading
-OSM files. Dealing with unnecessary information in OSM files is left to the
-developer. If you dont want to create your own pre-processing script, we recommend
-you to use `Òverpass-Api`. [Here](resources/osm/overpass-api-query.txt) is an example
-query that we use to get only `pedestrian` relevant paths. You can customize it
-however you want; once you are done, click `Export` and get the
-`raw data directly from Overpass API` link; with it you can execute the query on a
-terminal or script.
+You can customize it however you want; once you are done, simply save the query run the
+preprocessing script again with `lein preprocess resources/`. This will preprocess
+all gtfs configs in your environment variables with (automatically) downloaded osm data.
 
 ## License
 `kamal` is distributed under LGPL v3

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.11.0"
+(defproject hiposfer/kamal "0.11.1"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"

--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,7 @@
   :aliases {"preprocess" ["trampoline" "run" "-m" "hiposfer.kamal.preprocessor"]}
   :profiles {:dev {:dependencies [[criterium "0.4.4"]  ;; benchmark
                                   [expound "0.7.0"]
+                                  [markdown2clj "0.1.3"]
                                   [org.clojure/tools.namespace "0.2.11"]]
                    :plugins [[jonase/eastwood "0.2.6"]]
                    :eastwood {:config-files ["resources/eastwood.clj"]}}

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,6 @@
                  [hiposfer/geojson.specs "0.2.0"]
                  [com.taoensso/timbre "4.10.0"]
                  [com.stuartsierra/component "0.3.2"]
-                 [org.apache.commons/commons-compress "1.17"] ;;bz2 files read
                  [org.teneighty/java-heaps "1.0.0"]
                  [org.clojure/data.csv "0.1.4"]
                  [datascript "0.16.6"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.11.1"
+(defproject hiposfer/kamal "0.12.0"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"

--- a/project.clj
+++ b/project.clj
@@ -30,8 +30,8 @@
              :release {:aot [hiposfer.kamal.core] ;; compile the entry point and all of its dependencies}
                        :main hiposfer.kamal.core
                        :uberjar-name "kamal.jar"
-                       :jar-exclusions [#".*\.bz2"]
-                       :uberjar-exclusions [#".*\.bz2"]
+                       :jar-exclusions [#".*\.gzip" #".*\.zip"]
+                       :uberjar-exclusions [#".*\.gzip" #".*\.zip"]
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}}
   :test-selectors {:default (complement :benchmark)
                    :benchmark :benchmark}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.10.0"
+(defproject hiposfer/kamal "0.11.0"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"
@@ -24,10 +24,8 @@
   :aliases {"preprocess" ["trampoline" "run" "-m" "hiposfer.kamal.preprocessor"]}
   :profiles {:dev {:dependencies [[criterium "0.4.4"]  ;; benchmark
                                   [expound "0.7.0"]
-                                  [io.aviso/pretty "0.1.34"]
                                   [org.clojure/tools.namespace "0.2.11"]]
-                   :plugins [[jonase/eastwood "0.2.6"]
-                             [io.aviso/pretty "0.1.34"]]
+                   :plugins [[jonase/eastwood "0.2.6"]]
                    :eastwood {:config-files ["resources/eastwood.clj"]}}
              :release {:aot [hiposfer.kamal.core] ;; compile the entry point and all of its dependencies}
                        :main hiposfer.kamal.core

--- a/resources/eastwood.clj
+++ b/resources/eastwood.clj
@@ -14,3 +14,9 @@
                                   'clojure.spec/coll-of 'clojure.spec.alpha/coll-of}
    :within-depth 6
    :reason "clojure.spec's macros `keys`, `every`, and `and` often contain `clojure.core/and` invocations with only one argument."})
+
+(disable-warning
+  {:linter :wrong-arity
+   :function-symbol 'clojure.core/eduction
+   :arglists-for-linting '([& xform])
+   :reason "eduction takes a sequence of transducer with a collection as the last item"})

--- a/resources/gtfs/reference.edn
+++ b/resources/gtfs/reference.edn
@@ -1,0 +1,613 @@
+{:meta {:revised "August 9, 2018"
+        :original "https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md"
+        :description "This document explains the types of files that comprise a GTFS transit feed and defines the fields used in all of those files."}
+ :definitions {:required "The field column must be included in your feed, and a value must be provided for each record. Some required fields permit an empty string as a value. To enter an empty string, just omit any text between the commas for that field. Note that 0 is interpreted as \"a string of value 0\", and is not an empty string. Please see the field definition for details"
+               :optional "The field column may be omitted from your feed. If you choose to include an optional column, each record in your feed must have a value for that column. You may include an empty string as a value for records that do not have values for the column. Some optional fields permit an empty string as a value. To enter an empty string, just omit any text between the commas for that field. Note that 0 is interpreted as \"a string of value 0\", and is not an empty string."
+               :unique   " The field contains a value that maps to a single distinct entity within the column. For example, if a route is assigned the ID 1A, then no other route may use that route ID. However, you may assign the ID 1A to a location because locations are a different type of entity than routes"}
+ :feed-files
+ ({:filename "agency.txt",
+   :required true,
+   :defines
+   "One or more transit agencies that provide the data in this feed."}
+  {:filename "stops.txt",
+   :required true,
+   :defines
+   "Individual locations where vehicles pick up or drop off passengers."}
+  {:filename "routes.txt",
+   :required true,
+   :defines
+   "Transit routes. A route is a group of trips that are displayed to riders as a single service."}
+  {:filename "trips.txt",
+   :required true,
+   :defines
+   "Trips for each route. A trip is a sequence of two or more stops that occurs at specific time."}
+  {:filename "stop_times.txt",
+   :required true,
+   :defines
+   "Times that a vehicle arrives at and departs from individual stops for each trip."}
+  {:filename "calendar.txt",
+   :required true,
+   :defines
+   "Dates for service IDs using a weekly schedule. Specify when service starts and ends, as well as days of the week where service is available."}
+  {:filename "calendar_dates.txt",
+   :required false,
+   :defines
+   "Exceptions for the service IDs defined in the calendar.txt file. If calendar.txt includes ALL dates of service, this file may be specified instead of calendar.txt."}
+  {:filename "fare_attributes.txt",
+   :required false,
+   :defines "Fare information for a transit organization's routes."}
+  {:filename "fare_rules.txt",
+   :required false,
+   :defines
+   "Rules for applying fare information for a transit organization's routes."}
+  {:filename "shapes.txt",
+   :required false,
+   :defines
+   "Rules for drawing lines on a map to represent a transit organization's routes."}
+  {:filename "frequencies.txt",
+   :required false,
+   :defines
+   "Headway (time between trips) for routes with variable frequency of service."}
+  {:filename "transfers.txt",
+   :required false,
+   :defines
+   "Rules for making connections at transfer points between routes."}
+  {:filename "feed_info.txt",
+   :required false,
+   :defines
+   "Additional information about the feed itself, including publisher, version, and expiration information."}),
+ :field-definitions
+ ({:filename "agency.txt",
+   :fields
+   ({:field-name "agency_id",
+     :required false,
+     :details
+     "The agency_id field is an ID that uniquely identifies a transit agency. A transit feed may represent data from more than one agency. The agency_id is dataset unique. This field is optional for transit feeds that only contain data for a single agency.",
+     :unique true}
+    {:field-name "agency_name",
+     :required true,
+     :details
+     "The agency_name field contains the full name of the transit agency. Google Maps will display this name."}
+    {:field-name "agency_url",
+     :required true,
+     :details
+     "The agency_url field contains the URL of the transit agency. The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
+    {:field-name "agency_timezone",
+     :required true,
+     :details
+     "The agency_timezone field contains the timezone where the transit agency is located. Timezone names never contain the space character but may contain an underscore. Please refer to http://en.wikipedia.org/wiki/List_of_tz_zones for a list of valid values. If multiple agencies are specified in the feed, each must have the same agency_timezone."}
+    {:field-name "agency_lang",
+     :required false,
+     :details
+     "The agency_lang field contains a two-letter ISO 639-1 code for the primary language used by this transit agency. The language code is case-insensitive (both en and EN are accepted). This setting defines capitalization rules and other language-specific settings for all text contained in this transit agency's feed. Please refer to http://www.loc.gov/standards/iso639-2/php/code_list.php for a list of valid values."}
+    {:field-name "agency_phone",
+     :required false,
+     :details
+     "The agency_phone field contains a single voice telephone number for the specified agency. This field is a string value that presents the telephone number as typical for the agency's service area. It can and should contain punctuation marks to group the digits of the number. Dialable text (for example, TriMet's \"503-238-RIDE\") is permitted, but the field must not contain any other descriptive text."}
+    {:field-name "agency_fare_url",
+     :required false,
+     :details
+     "The agency_fare_url specifies the URL of a web page that allows a rider to purchase tickets or other fare instruments for that agency online. The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
+    {:field-name "agency_email",
+     :required false,
+     :details
+     "Contains a single valid email address actively monitored by the agency’s customer service department. This email address will be considered a direct contact point where transit riders can reach a customer service representative at the agency."})}
+  {:filename "stops.txt",
+   :fields
+   ({:field-name "stop_id",
+     :required true,
+     :details
+     "The stop_id field contains an ID that uniquely identifies a stop, station, or station entrance. Multiple routes may use the same stop. The stop_id is used by systems as an internal identifier of this record (e.g., primary key in database), and therefore the stop_id must be dataset unique.",
+     :unique true}
+    {:field-name "stop_code",
+     :required false,
+     :details
+     "The stop_code field contains short text or a number that uniquely identifies the stop for passengers. Stop codes are often used in phone-based transit information systems or printed on stop signage to make it easier for riders to get a stop schedule or real-time arrival information for a particular stop.  The stop_code field contains short text or a number that uniquely identifies the stop for passengers. The stop_code can be the same as stop_id if it is passenger-facing. This field should be left blank for stops without a code presented to passengers."}
+    {:field-name "stop_name",
+     :required true,
+     :details
+     "The stop_name field contains the name of a stop, station, or station entrance. Please use a name that people will understand in the local and tourist vernacular."}
+    {:field-name "stop_desc",
+     :required false,
+     :details
+     "The stop_desc field contains a description of a stop. Please provide useful, quality information. Do not simply duplicate the name of the stop."}
+    {:field-name "stop_lat",
+     :required true,
+     :details
+     "The stop_lat field contains the latitude of a stop, station, or station entrance. The field value must be a valid WGS 84 latitude."}
+    {:field-name "stop_lon",
+     :required true,
+     :details
+     "The stop_lon field contains the longitude of a stop, station, or station entrance. The field value must be a valid WGS 84 longitude value from -180 to 180."}
+    {:field-name "zone_id",
+     :required false,
+     :details
+     "The zone_id field defines the fare zone for a stop ID. Zone IDs are required if you want to provide fare information using fare_rules.txt. If this stop ID represents a station, the zone ID is ignored."}
+    {:field-name "stop_url",
+     :required false,
+     :details
+     "The stop_url field contains the URL of a web page about a particular stop. This should be different from the agency_url and the route_url fields.  The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
+    {:field-name "location_type",
+     :required false,
+     :details
+     "The location_type field identifies whether this stop ID represents a stop, station, or station entrance. If no location type is specified, or the location_type is blank, stop IDs are treated as stops. Stations may have different properties from stops when they are represented on a map or used in trip planning.  The location type field can have the following values:",
+     :values
+     ({:value 0
+       :description "Stop. A location where passengers board or disembark from a transit vehicle."}
+      {:description
+       "Station. A physical structure or area that contains one or more stop.",
+       :value 1}
+      {:description
+       "Station Entrance/Exit. A location where passengers can enter or exit a station from the street. The stop entry must also specify a parent_station value referencing the stop ID of the parent station for the entrance.",
+       :value 2})}
+    {:field-name "parent_station",
+     :required false,
+     :details
+     "For stops that are physically located inside stations, the parent_station field identifies the station associated with the stop. To use this field, stops.txt must also contain a row where this stop ID is assigned location type=1."}
+    {:field-name "stop_timezone",
+     :required false,
+     :details
+     "The stop_timezone field contains the timezone in which this stop, station, or station entrance is located. Please refer to Wikipedia List of Timezones for a list of valid values. If omitted, the stop should be assumed to be located in the timezone specified by agency_timezone in agency.txt.   When a stop has a parent station, the stop is considered to be in the timezone specified by the parent station's stop_timezone value. If the parent has no stop_timezone value, the stops that belong to that station are assumed to be in the timezone specified by agency_timezone, even if the stops have their own stop_timezone values. In other words, if a given stop has a parent_station value, any stop_timezone value specified for that stop must be ignored.  Even if stop_timezone values are provided in stops.txt, the times in stop_times.txt should continue to be specified as time since midnight in the timezone specified by agency_timezone in agency.txt. This ensures that the time values in a trip always increase over the course of a trip, regardless of which timezones the trip crosses."}
+    {:field-name "wheelchair_boarding",
+     :required false,
+     :details
+     "The wheelchair_boarding field identifies whether wheelchair boardings are possible from the specified stop, station, or station entrance. The field can have the following values:",
+     :values
+     ({:value 0
+       :description "indicates that there is no accessibility information for the stop"}
+      {:description
+       "indicates that at least some vehicles at this stop can be boarded by a rider in a wheelchair",
+       :value 1}
+      {:description "wheelchair boarding is not possible at this stop",
+       :value 2}
+      "When a stop is part of a larger station complex, as indicated by a stop with a parent_station value, the stop's wheelchair_boarding field has the following additional semantics:"
+      {:value 0
+       :description "the stop will inherit its wheelchair_boarding value from the parent station, if specified in the parent"}
+      {:description
+       "there exists some accessible path from outside the station to the specific stop / platform",
+       :value 1}
+      {:description
+       "there exists no accessible path from outside the station to the specific stop / platform",
+       :value 2}
+      "For station entrances, the wheelchair_boarding field has the following additional semantics:"
+      {:value 0
+       :description "the station entrance will inherit its wheelchair_boarding value from the parent station, if specified in the parent"}
+      {:description
+       "the station entrance is wheelchair accessible (e.g. an elevator is available to platforms if they are not at-grade)",
+       :value 1}
+      {:description
+       "there exists no accessible path from the entrance to station platforms",
+       :value 2})})}
+  {:filename "routes.txt",
+   :fields
+   ({:field-name "route_id",
+     :required true,
+     :details
+     "The route_id field contains an ID that uniquely identifies a route. The route_id is dataset unique.",
+     :unique true}
+    {:field-name "agency_id",
+     :required false,
+     :details
+     "The agency_id field defines an agency for the specified route. This value is referenced from the agency.txt file. Use this field when you are providing data for routes from more than one agency."}
+    {:field-name "route_short_name",
+     :required true,
+     :details
+     "The route_short_name contains the short name of a route. This will often be a short, abstract identifier like \"32\", \"100X\", or \"Green\" that riders use to identify a route, but which doesn't give any indication of what places the route serves. At least one of route_short_name or route_long_name must be specified, or potentially both if appropriate. If the route does not have a short name, please specify a route_long_name and use an empty string as the value for this field."}
+    {:field-name "route_long_name",
+     :required true,
+     :details
+     "The route_long_name contains the full name of a route. This name is generally more descriptive than the route_short_name and will often include the route's destination or stop. At least one of route_short_name or route_long_name must be specified, or potentially both if appropriate. If the route does not have a long name, please specify a route_short_name and use an empty string as the value for this field."}
+    {:field-name "route_desc",
+     :required false,
+     :details
+     "The route_desc field contains a description of a route. Please provide useful, quality information. Do not simply duplicate the name of the route. For example, \"A trains operate between Inwood-207 St, Manhattan and Far Rockaway-Mott Avenue, Queens at all times. Also from about 6AM until about midnight, additional A trains operate between Inwood-207 St and Lefferts Boulevard (trains typically alternate between Lefferts Blvd and Far Rockaway).\""}
+    {:field-name "route_type",
+     :required true,
+     :details
+     "The route_type field describes the type of transportation used on a route. Valid values for this field are:",
+     :values
+     ({:description
+       "Tram, Streetcar, Light rail. Any light rail or street level system within a metropolitan area.",
+       :value 0}
+      {:description
+       "Subway, Metro. Any underground rail system within a metropolitan area.",
+       :value 1}
+      {:description
+       "Rail. Used for intercity or long-distance travel.",
+       :value 2}
+      {:description
+       "Bus. Used for short- and long-distance bus routes.",
+       :value 3}
+      {:description
+       "Ferry. Used for short- and long-distance boat service.",
+       :value 4}
+      {:description
+       "Cable car. Used for street-level cable cars where the cable runs beneath the car.",
+       :value 5}
+      {:description
+       "Gondola, Suspended cable car. Typically used for aerial cable cars where the car is suspended from the cable.",
+       :value 6}
+      {:description
+       "Funicular. Any rail system designed for steep inclines.",
+       :value 7})}
+    {:field-name "route_url",
+     :required false,
+     :details
+     "The route_url field contains the URL of a web page about that particular route. This should be different from the agency_url.  The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
+    {:field-name "route_color",
+     :required false,
+     :details
+     "In systems that have colors assigned to routes, the route_color field defines a color that corresponds to a route. The color must be provided as a six-character hexadecimal number, for example, 00FFFF. If no color is specified, the default route color is white (FFFFFF).  The color difference between route_color and route_text_color should provide sufficient contrast when viewed on a black and white screen. The W3C Techniques for Accessibility Evaluation And Repair Tools document offers a useful algorithm for evaluating color contrast. There are also helpful online tools for choosing contrasting colors, including the snook.ca Color Contrast Check application."}
+    {:field-name "route_text_color",
+     :required false,
+     :details
+     "The route_text_color field can be used to specify a legible color to use for text drawn against a background of route_color. The color must be provided as a six-character hexadecimal number, for example, FFD700. If no color is specified, the default text color is black (000000).  The color difference between route_color and route_text_color should provide sufficient contrast when viewed on a black and white screen."}
+    {:field-name "route_sort_order",
+     :required false,
+     :details
+     "The route_sort_order field can be used to order the routes in a way which is ideal for presentation to customers. It must be a non-negative integer. Routes with smaller route_sort_order values should be displayed before routes with larger route_sort_order values."})}
+  {:filename "trips.txt",
+   :fields
+   ({:field-name "route_id",
+     :required true,
+     :details
+     "The route_id field contains an ID that uniquely identifies a route. This value is referenced from the routes.txt file."}
+    {:field-name "service_id",
+     :required true,
+     :details
+     "The service_id contains an ID that uniquely identifies a set of dates when service is available for one or more routes. This value is referenced from the calendar.txt or calendar_dates.txt file."}
+    {:field-name "trip_id",
+     :required true,
+     :details
+     "The trip_id field contains an ID that identifies a trip. The trip_id is dataset unique.",
+     :unique true}
+    {:field-name "trip_headsign",
+     :required false,
+     :details
+     "The trip_headsign field contains the text that appears on a sign that identifies the trip's destination to passengers. Use this field to distinguish between different patterns of service in the same route. If the headsign changes during a trip, you can override the trip_headsign by specifying values for the stop_headsign field in stop_times.txt."}
+    {:field-name "trip_short_name",
+     :required false,
+     :details
+     "The trip_short_name field contains the text that appears in schedules and sign boards to identify the trip to passengers, for example, to identify train numbers for commuter rail trips. If riders do not commonly rely on trip names, please leave this field blank.  A trip_short_name value, if provided, should uniquely identify a trip within a service day; it should not be used for destination names or limited/express designations."}
+    {:field-name "direction_id",
+     :required false,
+     :details
+     "The direction_id field contains a binary value that indicates the direction of travel for a trip. Use this field to distinguish between bi-directional trips with the same route_id. This field is not used in routing; it provides a way to separate trips by direction when publishing time tables. You can specify names for each direction with the trip_headsign field.
+     For example, you could use the trip_headsign and direction_id fields together to assign a name to travel in each direction for a set of trips. A trips.txt file could contain these rows for use in time tables:
+     * trip_id,...,trip_headsign,direction_id
+     * 1234,...,Airport,0
+     * 1505,...,Downtown,1",
+     :values
+     ({:description "travel in one direction (e.g. outbound travel)",
+       :value 0}
+      {:description
+       "travel in the opposite direction (e.g. inbound travel)",
+       :value 1})}
+    {:field-name "block_id",
+     :required false,
+     :details
+     "The block_id field identifies the block to which the trip belongs. A block consists of a single trip or many sequential trips made using the same vehicle, defined by shared service day and block_id. A block_id can have trips with different service days, making distinct blocks. (See example below)"}
+    {:field-name "shape_id",
+     :required false,
+     :details
+     "The shape_id field contains an ID that defines a shape for the trip. This value is referenced from the shapes.txt file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip."}
+    {:field-name "wheelchair_accessible",
+     :required false,
+     :details "accessibility information",
+     :values
+     ({:value 0
+       :description "indicates that there is no accessibility information for the trip"}
+      {:description
+       "indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair",
+       :value 1}
+      {:description
+       "indicates that no riders in wheelchairs can be accommodated on this trip",
+       :value 2})}
+    {:field-name "bikes_allowed",
+     :required false,
+     :details "indicates if bikes are allowed inside vehicle",
+     :values
+     ({:value 0
+       :description "indicates that there is no bike information for the trip"}
+      {:description
+       "indicates that the vehicle being used on this particular trip can accommodate at least one bicycle",
+       :value 1}
+      {:description
+       "indicates that no bicycles are allowed on this trip",
+       :value 2})})}
+  {:filename "stop_times.txt",
+   :fields
+   ({:field-name "trip_id",
+     :required true,
+     :details
+     "The trip_id field contains an ID that identifies a trip. This value is referenced from the trips.txt file."}
+    {:field-name "arrival_time",
+     :required true,
+     :details
+     "The arrival_time specifies the arrival time at a specific stop for a specific trip on a route. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. If you don't have separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time.Scheduled stops where the vehicle strictly adheres to the specified arrival and departure times are timepoints. For example, if a transit vehicle arrives at a stop before the scheduled departure time, it will hold until the departure time. If this stop is not a timepoint, use either an empty string value for the arrival_time field or provide an interpolated time. Further, indicate that interpolated times are provided via the timepoint field with a value of zero. If interpolated times are indicated with timepoint=0, then time points must be indicated with a value of 1 for the timepoint field. Provide arrival times for all stops that are time points.An arrival time must be specified for the first and the last stop in a trip. Times must be eight digits in HH:MM:SS format (H:MM:SS is also accepted, if the hour begins with 0). Do not pad times with spaces. The following columns list stop times for a trip and the proper way to express those times in the arrival_time field:"}
+    {:field-name "departure_time",
+     :required true,
+     :details
+     "The departure_time specifies the departure time from a specific stop for a specific trip on a route. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. If you don't have separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time.Scheduled stops where the vehicle strictly adheres to the specified arrival and departure times are timepoints. For example, if a transit vehicle arrives at a stop before the scheduled departure time, it will hold until the departure time. If this stop is not a timepoint, use either an empty string value for the departure_time field or provide an interpolated time (further, indicate that interpolated times are provided via the timepoint field with a value of zero). If interpolated times are indicated with timepoint=0, then time points must be indicated with a value of 1 for the timepoint field. Provide departure times for all stops that are time points.A departure time must be specified for the first and the last stop in a trip even if the vehicle does not allow boarding at the last stop.  Times must be eight digits in HH:MM:SS format (H:MM:SS is also accepted, if the hour begins with 0). Do not pad times with spaces. The following columns list stop times for a trip and the proper way to express those times in the departure_time field:"}
+    {:field-name "stop_id",
+     :required true,
+     :details
+     "The stop_id field contains an ID that uniquely identifies a stop. Multiple routes may use the same stop. The stop_id is referenced from the stops.txt file. If location_type is used in stops.txt, all stops referenced in stop_times.txt must have location_type of 0.  Where possible, stop_id values should remain consistent between feed updates. In other words, stop A with stop_id 1 should have stop_id 1 in all subsequent data updates. If a stop is not a time point, enter blank values for arrival_time and departure_time."}
+    {:field-name "stop_sequence",
+     :required true,
+     :details
+     "The stop_sequence field identifies the order of the stops for a particular trip. The values for stop_sequence must be non-negative integers, and they must increase along the trip.  For example, the first stop on the trip could have a stop_sequence of 1, the second stop on the trip could have a stop_sequence of 23, the third stop could have a stop_sequence of 40, and so on."}
+    {:field-name "stop_headsign",
+     :required false,
+     :details
+     "The stop_headsign field contains the text that appears on a sign that identifies the trip's destination to passengers. Use this field to override the default trip_headsign when the headsign changes between stops. If this headsign is associated with an entire trip, use trip_headsign instead."}
+    {:field-name "pickup_type",
+     :required false,
+     :details
+     "The pickup_type field indicates whether passengers are picked up at a stop as part of the normal schedule or whether a pickup at the stop is not available. This field also allows the transit agency to indicate that passengers must call the agency or notify the driver to arrange a pickup at a particular stop. Valid values for this field are:",
+     :values
+     ({:description "Regularly scheduled pickup", :value 0}
+      {:description "No pickup available", :value 1}
+      {:description "Must phone agency to arrange pickup", :value 2}
+      {:description "Must coordinate with driver to arrange pickup",
+       :value 3}
+      "The default value for this field is 0.")}
+    {:field-name "drop_off_type",
+     :required false,
+     :details
+     "The drop_off_type field indicates whether passengers are dropped off at a stop as part of the normal schedule or whether a drop off at the stop is not available. This field also allows the transit agency to indicate that passengers must call the agency or notify the driver to arrange a drop off at a particular stop. Valid values for this field are:",
+     :values
+     ({:description "Regularly scheduled drop off", :value 0}
+      {:description "No drop off available", :value 1}
+      {:description "Must phone agency to arrange drop off", :value 2}
+      {:description "Must coordinate with driver to arrange drop off",
+       :value 3}
+      "The default value for this field is 0.")}
+    {:field-name "shape_dist_traveled",
+     :required false,
+     :details
+     "When used in the stop_times.txt file, the shape_dist_traveled field positions a stop as a distance from the first shape point. The shape_dist_traveled field represents a real distance traveled along the route in units such as feet or kilometers. For example, if a bus travels a distance of 5.25 kilometers from the start of the shape to the stop, the shape_dist_traveled for the stop ID would be entered as \"5.25\". This information allows the trip planner to determine how much of the shape to draw when showing part of a trip on the map. The values used for shape_dist_traveled must increase along with stop_sequence: they cannot be used to show reverse travel along a route.  The units used for shape_dist_traveled in the stop_times.txt file must match the units that are used for this field in the shapes.txt file."}
+    {:field-name "timepoint",
+     :required false,
+     :details
+     "The timepoint field can be used to indicate if the specified arrival and departure times for a stop are strictly adhered to by the transit vehicle or if they are instead approximate and/or interpolated times. The field allows a GTFS producer to provide interpolated stop times that potentially incorporate local knowledge, but still indicate if the times are approximate. For stop-time entries with specified arrival and departure times, valid values for this field are:",
+     :values
+     ("* empty - Times are considered exact."
+      {:description "Times are considered approximate.", :value 0}
+      {:description "Times are considered exact.", :value 1}
+      "For stop-time entries without specified arrival and departure times, feed consumers must interpolate arrival and departure times. Feed producers may optionally indicate that such an entry is not a timepoint (value=0) but it is an error to mark a entry as a timepoint (value=1) without specifying arrival and departure times.")})}
+  {:filename "calendar.txt",
+   :fields
+   ({:field-name "service_id",
+     :required true,
+     :details
+     "The service_id contains an ID that uniquely identifies a set of dates when service is available for one or more routes. Each service_id value can appear at most once in a calendar.txt file. This value is dataset unique. It is referenced by the trips.txt file.",
+     :unique true}
+    {:field-name "monday",
+     :required true,
+     :details
+     "The monday field contains a binary value that indicates whether the service is valid for all Mondays."}
+    {:field-name "tuesday",
+     :required true,
+     :details
+     "The tuesday field contains a binary value that indicates whether the service is valid for all Tuesdays."}
+    {:field-name "wednesday",
+     :required true,
+     :details
+     "The wednesday field contains a binary value that indicates whether the service is valid for all Wednesdays."}
+    {:field-name "thursday",
+     :required true,
+     :details
+     "The thursday field contains a binary value that indicates whether the service is valid for all Thursdays."}
+    {:field-name "friday",
+     :required true,
+     :details
+     "The friday field contains a binary value that indicates whether the service is valid for all Fridays."}
+    {:field-name "saturday",
+     :required true,
+     :details
+     "The saturday field contains a binary value that indicates whether the service is valid for all Saturdays."}
+    {:field-name "sunday",
+     :required true,
+     :details
+     "The sunday field contains a binary value that indicates whether the service is valid for all Sundays."}
+    {:field-name "start_date",
+     :required true,
+     :details
+     "The start_date field contains the start date for the service.  The start_date field's value should be in YYYYMMDD format."}
+    {:field-name "end_date",
+     :required true,
+     :details
+     "The end_date field contains the end date for the service. This date is included in the service interval.  The end_date field's value should be in YYYYMMDD format."})}
+  {:filename "calendar_dates.txt",
+   :fields
+   ({:field-name "service_id",
+     :required true,
+     :details
+     "The service_id contains an ID that uniquely identifies a set of dates when a service exception is available for one or more routes. Each (service_id, date) pair can only appear once in calendar_dates.txt. If the a service_id value appears in both the calendar.txt and calendar_dates.txt files, the information in calendar_dates.txt modifies the service information specified in calendar.txt. This field is referenced by the trips.txt file."}
+    {:field-name "date",
+     :required true,
+     :details
+     "The date field specifies a particular date when service availability is different than the norm. You can use the exception_type field to indicate whether service is available on the specified date. The date field's value should be in YYYYMMDD format."}
+    {:field-name "exception_type",
+     :required true,
+     :details
+     "The exception_type indicates whether service is available on the date specified in the date field.
+
+     For example, suppose a route has one set of trips available on holidays and another set of trips available on all other days. You could have one service_id that corresponds to the regular service schedule and another service_id that corresponds to the holiday schedule. For a particular holiday, you would use the calendar_dates.txt file to add the holiday to the holiday service_id and to remove the holiday from the regular service_id schedule.",
+     :values
+     ({:value 1
+       :description "service added for the specified date."}
+      {:value 2
+       :description "service removed for the specified date."})})}
+  {:filename "fare_attributes.txt",
+   :fields
+   ({:field-name "fare_id",
+     :required true,
+     :details
+     "The fare_id field contains an ID that uniquely identifies a fare class. The fare_id is dataset unique.",
+     :unique true}
+    {:field-name "price",
+     :required true,
+     :details
+     "The price field contains the fare price, in the unit specified by currency_type."}
+    {:field-name "currency_type",
+     :required true,
+     :details
+     "The currency_type field defines the currency used to pay the fare. Please use the ISO 4217 alphabetical currency codes which can be found at the following URL: http://en.wikipedia.org/wiki/ISO_4217."}
+    {:field-name "payment_method",
+     :required true,
+     :details
+     "The payment_method field indicates when the fare must be paid. Valid values for this field are:",
+     :values
+     ({:description "Fare is paid on board.", :value 0}
+      {:description "Fare must be paid before boarding.", :value 1})}
+    {:field-name "transfers",
+     :required true,
+     :details
+     "The transfers field specifies the number of transfers permitted on this fare.
+      Valid values for this field are:",
+     :values
+     ({:description "unlimited transfers are permitted" :value ""}
+      {:description "No transfers permitted on this fare.", :value 0}
+      {:description "Passenger may transfer once.", :value 1}
+      {:description "Passenger may transfer twice.", :value 2})}
+    {:field-name "agency_id",
+     :required false,
+     :details
+     "Required for feeds with multiple agencies defined in the agency.txt file. Each fare attribute must specify an agency_id value to indicate which agency the fare applies to."}
+    {:field-name "transfer_duration",
+     :required false,
+     :details
+     "The transfer_duration field specifies the length of time in seconds before a transfer expires.  When used with a transfers value of 0, the transfer_duration field indicates how long a ticket is valid for a fare where no transfers are allowed. Unless you intend to use this field to indicate ticket validity, transfer_duration should be omitted or empty when transfers is set to 0."})}
+  {:filename "fare_rules.txt",
+   :fields
+   ({:field-name "fare_id",
+     :required true,
+     :details
+     "The fare_id field contains an ID that uniquely identifies a fare class. This value is referenced from the fare_attributes.txt file."}
+    {:field-name "route_id",
+     :required false,
+     :details
+     "The route_id field associates the fare ID with a route. Route IDs are referenced from the routes.txt file. If you have several routes with the same fare attributes, create a row in fare_rules.txt for each route."}
+    {:field-name "origin_id",
+     :required false,
+     :details
+     "The origin_id field associates the fare ID with an origin zone ID. Zone IDs are referenced from the stops.txt file. If you have several origin IDs with the same fare attributes, create a row in fare_rules.txt for each origin ID."}
+    {:field-name "destination_id",
+     :required false,
+     :details
+     "The destination_id field associates the fare ID with a destination zone ID. Zone IDs are referenced from the stops.txt file. If you have several destination IDs with the same fare attributes, create a row in fare_rules.txt for each destination ID."}
+    {:field-name "contains_id",
+     :required false,
+     :details
+     "The contains_id field associates the fare ID with a zone ID, referenced from the stops.txt file. The fare ID is then associated with itineraries that pass through every contains_id zone."})}
+  {:filename "shapes.txt",
+   :fields
+   ({:field-name "shape_id",
+     :required true,
+     :details
+     "The shape_id field contains an ID that uniquely identifies a shape."}
+    {:field-name "shape_pt_lat",
+     :required true,
+     :details
+     "The shape_pt_lat field associates a shape point's latitude with a shape ID. The field value must be a valid WGS 84 latitude. Each row in shapes.txt represents a shape point in your shape definition."}
+    {:field-name "shape_pt_lon",
+     :required true,
+     :details
+     "The shape_pt_lon field associates a shape point's longitude with a shape ID. The field value must be a valid WGS 84 longitude value from -180 to 180. Each row in shapes.txt represents a shape point in your shape definition."}
+    {:field-name "shape_pt_sequence",
+     :required true,
+     :details
+     "The shape_pt_sequence field associates the latitude and longitude of a shape point with its sequence order along the shape. The values for shape_pt_sequence must be non-negative integers, and they must increase along the trip."}
+    {:field-name "shape_dist_traveled",
+     :required false,
+     :details
+     "When used in the shapes.txt file, the shape_dist_traveled field positions a shape point as a distance traveled along a shape from the first shape point. The shape_dist_traveled field represents a real distance traveled along the route in units such as feet or kilometers. This information allows the trip planner to determine how much of the shape to draw when showing part of a trip on the map. The values used for shape_dist_traveled must increase along with shape_pt_sequence: they cannot be used to show reverse travel along a route."})}
+  {:filename "frequencies.txt",
+   :fields
+   ({:field-name "trip_id",
+     :required true,
+     :details
+     "The trip_id contains an ID that identifies a trip on which the specified frequency of service applies. Trip IDs are referenced from the trips.txt file."}
+    {:field-name "start_time",
+     :required true,
+     :details
+     "The start_time field specifies the time at which the first vehicle departs from the first stop of the trip with the specified frequency. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. E.g. 25:35:00."}
+    {:field-name "end_time",
+     :required true,
+     :details
+     "The end_time field indicates the time at which service changes to a different frequency (or ceases) at the first stop in the trip. The time is measured from \"noon minus 12h\" (effectively midnight, except for days on which daylight savings time changes occur) at the beginning of the service day. For times occurring after midnight, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. E.g. 25:35:00."}
+    {:field-name "headway_secs",
+     :required true,
+     :details
+     "The headway_secs field indicates the time between departures from the same stop (headway) for this trip type, during the time interval specified by start_time and end_time. The headway value must be entered in seconds."}
+    {:field-name "exact_times",
+     :required false,
+     :details
+     "The exact_times field determines if frequency-based trips should be exactly scheduled based on the specified headway information.
+
+      The value of exact_times must be the same for all frequencies.txt rows with the same trip_id. If exact_times is 1 and a frequencies.txt row has a start_time equal to end_time, no trip must be scheduled. When exact_times is 1, care must be taken to choose an end_time value that is greater than the last desired trip start time but less than the last desired trip start time + headway_secs.
+
+      Valid values for this field are:",
+     :values
+     ({:value 0
+       :description "Frequency-based trips are not exactly scheduled. This is the default behavior."}
+      {:description
+       "Frequency-based trips are exactly scheduled. For a frequencies.txt row, trips are scheduled starting with trip_start_time = start_time + x * headway_secs for all x in (0, 1, 2, ...) where trip_start_time < end_time.",
+       :value 1})})}
+  {:filename "transfers.txt",
+   :fields
+   ({:field-name "from_stop_id",
+     :required true,
+     :details
+     "The from_stop_id field contains a stop ID that identifies a stop or station where a connection between routes begins. Stop IDs are referenced from the stops.txt file. If the stop ID refers to a station that contains multiple stops, this transfer rule applies to all stops in that station."}
+    {:field-name "to_stop_id",
+     :required true,
+     :details
+     "The to_stop_id field contains a stop ID that identifies a stop or station where a connection between routes ends. Stop IDs are referenced from the stops.txt file. If the stop ID refers to a station that contains multiple stops, this transfer rule applies to all stops in that station."}
+    {:field-name "transfer_type",
+     :required true,
+     :details
+     "The transfer_type field specifies the type of connection for the specified (from_stop_id, to_stop_id) pair. Valid values for this field are:",
+     :values
+     ({:value 0
+       :description "This is a recommended transfer point between routes."}
+      {:description
+       "This is a timed transfer point between two routes. The departing vehicle is expected to wait for the arriving one, with sufficient time for a passenger to transfer between routes.",
+       :value 1}
+      {:description
+       "This transfer requires a minimum amount of time between arrival and departure to ensure a connection. The time required to transfer is specified by min_transfer_time.",
+       :value 2}
+      {:description
+       "Transfers are not possible between routes at this location.",
+       :value 3})}
+    {:field-name "min_transfer_time",
+     :required false,
+     :details
+     "When a connection between routes requires an amount of time between arrival and departure (transfer_type=2), the min_transfer_time field defines the amount of time that must be available in an itinerary to permit a transfer between routes at these stops. The min_transfer_time must be sufficient to permit a typical rider to move between the two stops, including buffer time to allow for schedule variance on each route."})}
+  {:filename "feed_info.txt",
+   :fields
+   ({:field-name "feed_publisher_name",
+     :required true,
+     :details
+     "The feed_publisher_name field contains the full name of the organization that publishes the feed. (This may be the same as one of the agency_name values in agency.txt.) GTFS-consuming applications can display this name when giving attribution for a particular feed's data."}
+    {:field-name "feed_publisher_url",
+     :required true,
+     :details
+     "The feed_publisher_url field contains the URL of the feed publishing organization's website. (This may be the same as one of the agency_url values in agency.txt.) The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values."}
+    {:field-name "feed_lang",
+     :required true,
+     :details
+     "The feed_lang field contains a IETF BCP 47 language code specifying the default language used for the text in this feed. This setting helps GTFS consumers choose capitalization rules and other language-specific settings for the feed. For an introduction to IETF BCP 47, please refer to http://www.rfc-editor.org/rfc/bcp/bcp47.txt and http://www.w3.org/International/articles/language-tags/."}
+    {:field-name "feed_start_date",
+     :required false,
+     :details
+     "The feed provides complete and reliable schedule information for service in the period from the beginning of the feed_start_date day to the end of the feed_end_date day. Both days are given as dates in YYYYMMDD format as for calendar.txt, or left empty if unavailable. The feed_end_date date must not precede the feed_start_date date if both are given. Feed providers are encouraged to give schedule data outside this period to advise of likely future service, but feed consumers should treat it mindful of its non-authoritative status. If feed_start_date or feed_end_date extend beyond the active calendar dates defined in calendar.txt and calendar_dates.txt, the feed is making an explicit assertion that there is no service for dates within the feed_start_date or feed_end_date range but not included in the active calendar dates."}
+    {:field-name "feed_end_date",
+     :required false,
+     :details "(see above)"}
+    {:field-name "feed_version",
+     :required false,
+     :details
+     "The feed publisher can specify a string here that indicates the current version of their GTFS feed. GTFS-consuming applications can display this value to help feed publishers determine whether the latest version of their feed has been incorporated."})})}

--- a/resources/gtfs/reference.edn
+++ b/resources/gtfs/reference.edn
@@ -1,63 +1,13 @@
-{:meta {:revised "August 9, 2018"
+{:meta {:revised "September 1, 2018"
         :original "https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md"
         :description "This document explains the types of files that comprise a GTFS transit feed and defines the fields used in all of those files."}
  :definitions {:required "The field column must be included in your feed, and a value must be provided for each record. Some required fields permit an empty string as a value. To enter an empty string, just omit any text between the commas for that field. Note that 0 is interpreted as \"a string of value 0\", and is not an empty string. Please see the field definition for details"
                :optional "The field column may be omitted from your feed. If you choose to include an optional column, each record in your feed must have a value for that column. You may include an empty string as a value for records that do not have values for the column. Some optional fields permit an empty string as a value. To enter an empty string, just omit any text between the commas for that field. Note that 0 is interpreted as \"a string of value 0\", and is not an empty string."
                :unique   " The field contains a value that maps to a single distinct entity within the column. For example, if a route is assigned the ID 1A, then no other route may use that route ID. However, you may assign the ID 1A to a location because locations are a different type of entity than routes"}
- :feed-files
+ :feeds
  ({:filename "agency.txt",
    :required true,
-   :defines
-   "One or more transit agencies that provide the data in this feed."}
-  {:filename "stops.txt",
-   :required true,
-   :defines
-   "Individual locations where vehicles pick up or drop off passengers."}
-  {:filename "routes.txt",
-   :required true,
-   :defines
-   "Transit routes. A route is a group of trips that are displayed to riders as a single service."}
-  {:filename "trips.txt",
-   :required true,
-   :defines
-   "Trips for each route. A trip is a sequence of two or more stops that occurs at specific time."}
-  {:filename "stop_times.txt",
-   :required true,
-   :defines
-   "Times that a vehicle arrives at and departs from individual stops for each trip."}
-  {:filename "calendar.txt",
-   :required true,
-   :defines
-   "Dates for service IDs using a weekly schedule. Specify when service starts and ends, as well as days of the week where service is available."}
-  {:filename "calendar_dates.txt",
-   :required false,
-   :defines
-   "Exceptions for the service IDs defined in the calendar.txt file. If calendar.txt includes ALL dates of service, this file may be specified instead of calendar.txt."}
-  {:filename "fare_attributes.txt",
-   :required false,
-   :defines "Fare information for a transit organization's routes."}
-  {:filename "fare_rules.txt",
-   :required false,
-   :defines
-   "Rules for applying fare information for a transit organization's routes."}
-  {:filename "shapes.txt",
-   :required false,
-   :defines
-   "Rules for drawing lines on a map to represent a transit organization's routes."}
-  {:filename "frequencies.txt",
-   :required false,
-   :defines
-   "Headway (time between trips) for routes with variable frequency of service."}
-  {:filename "transfers.txt",
-   :required false,
-   :defines
-   "Rules for making connections at transfer points between routes."}
-  {:filename "feed_info.txt",
-   :required false,
-   :defines
-   "Additional information about the feed itself, including publisher, version, and expiration information."}),
- :field-definitions
- ({:filename "agency.txt",
+   :defines "One or more transit agencies that provide the data in this feed.",
    :fields
    ({:field-name "agency_id",
      :required false,
@@ -93,6 +43,8 @@
      :details
      "Contains a single valid email address actively monitored by the agency’s customer service department. This email address will be considered a direct contact point where transit riders can reach a customer service representative at the agency."})}
   {:filename "stops.txt",
+   :required true,
+   :defines "Individual locations where vehicles pick up or drop off passengers.",
    :fields
    ({:field-name "stop_id",
      :required true,
@@ -179,6 +131,8 @@
        "there exists no accessible path from the entrance to station platforms",
        :value 2})})}
   {:filename "routes.txt",
+   :required true,
+   :defines "Transit routes. A route is a group of trips that are displayed to riders as a single service.",
    :fields
    ({:field-name "route_id",
      :required true,
@@ -247,6 +201,8 @@
      :details
      "The route_sort_order field can be used to order the routes in a way which is ideal for presentation to customers. It must be a non-negative integer. Routes with smaller route_sort_order values should be displayed before routes with larger route_sort_order values."})}
   {:filename "trips.txt",
+   :required true,
+   :defines "Trips for each route. A trip is a sequence of two or more stops that occurs at specific time.",
    :fields
    ({:field-name "route_id",
      :required true,
@@ -316,6 +272,8 @@
        "indicates that no bicycles are allowed on this trip",
        :value 2})})}
   {:filename "stop_times.txt",
+   :required true,
+   :defines "Times that a vehicle arrives at and departs from individual stops for each trip.",
    :fields
    ({:field-name "trip_id",
      :required true,
@@ -377,6 +335,8 @@
       {:description "Times are considered exact.", :value 1}
       "For stop-time entries without specified arrival and departure times, feed consumers must interpolate arrival and departure times. Feed producers may optionally indicate that such an entry is not a timepoint (value=0) but it is an error to mark a entry as a timepoint (value=1) without specifying arrival and departure times.")})}
   {:filename "calendar.txt",
+   :required true,
+   :defines "Dates for service IDs using a weekly schedule. Specify when service starts and ends, as well as days of the week where service is available.",
    :fields
    ({:field-name "service_id",
      :required true,
@@ -420,6 +380,8 @@
      :details
      "The end_date field contains the end date for the service. This date is included in the service interval.  The end_date field's value should be in YYYYMMDD format."})}
   {:filename "calendar_dates.txt",
+   :required false,
+   :defines "Exceptions for the service IDs defined in the calendar.txt file. If calendar.txt includes ALL dates of service, this file may be specified instead of calendar.txt.",
    :fields
    ({:field-name "service_id",
      :required true,
@@ -441,6 +403,8 @@
       {:value 2
        :description "service removed for the specified date."})})}
   {:filename "fare_attributes.txt",
+   :required false,
+   :defines "Fare information for a transit organization's routes.",
    :fields
    ({:field-name "fare_id",
      :required true,
@@ -481,6 +445,8 @@
      :details
      "The transfer_duration field specifies the length of time in seconds before a transfer expires.  When used with a transfers value of 0, the transfer_duration field indicates how long a ticket is valid for a fare where no transfers are allowed. Unless you intend to use this field to indicate ticket validity, transfer_duration should be omitted or empty when transfers is set to 0."})}
   {:filename "fare_rules.txt",
+   :required false,
+   :defines "Rules for applying fare information for a transit organization's routes.",
    :fields
    ({:field-name "fare_id",
      :required true,
@@ -503,6 +469,8 @@
      :details
      "The contains_id field associates the fare ID with a zone ID, referenced from the stops.txt file. The fare ID is then associated with itineraries that pass through every contains_id zone."})}
   {:filename "shapes.txt",
+   :required false,
+   :defines "Rules for drawing lines on a map to represent a transit organization's routes.",
    :fields
    ({:field-name "shape_id",
      :required true,
@@ -525,6 +493,8 @@
      :details
      "When used in the shapes.txt file, the shape_dist_traveled field positions a shape point as a distance traveled along a shape from the first shape point. The shape_dist_traveled field represents a real distance traveled along the route in units such as feet or kilometers. This information allows the trip planner to determine how much of the shape to draw when showing part of a trip on the map. The values used for shape_dist_traveled must increase along with shape_pt_sequence: they cannot be used to show reverse travel along a route."})}
   {:filename "frequencies.txt",
+   :required false,
+   :defines "Headway (time between trips) for routes with variable frequency of service.",
    :fields
    ({:field-name "trip_id",
      :required true,
@@ -557,6 +527,8 @@
        "Frequency-based trips are exactly scheduled. For a frequencies.txt row, trips are scheduled starting with trip_start_time = start_time + x * headway_secs for all x in (0, 1, 2, ...) where trip_start_time < end_time.",
        :value 1})})}
   {:filename "transfers.txt",
+   :required false,
+   :defines "Rules for making connections at transfer points between routes.",
    :fields
    ({:field-name "from_stop_id",
      :required true,
@@ -587,6 +559,8 @@
      :details
      "When a connection between routes requires an amount of time between arrival and departure (transfer_type=2), the min_transfer_time field defines the amount of time that must be available in an itinerary to permit a transfer between routes at these stops. The min_transfer_time must be sufficient to permit a typical rider to move between the two stops, including buffer time to allow for schedule variance on each route."})}
   {:filename "feed_info.txt",
+   :required false,
+   :defines "Additional information about the feed itself, including publisher, version, and expiration information.",
    :fields
    ({:field-name "feed_publisher_name",
      :required true,

--- a/resources/kamal.postman_collection.json
+++ b/resources/kamal.postman_collection.json
@@ -42,24 +42,24 @@
 				],
 				"body": {},
 				"url": {
-					"raw": "localhost:3000/area/frankfurt/directions?departure=2018-05-07T10:15:30&coordinates=[[8.645333, 50.087314],[8.635897, 50.104172]]",
+					"raw": "localhost:3000/area/frankfurt-am-main/directions?departure=2018-08-31T17%3A06%3A37.897Z&coordinates=[[8.644231, 50.087102],[8.637313, 50.119479 ]]",
 					"host": [
 						"localhost"
 					],
 					"port": "3000",
 					"path": [
 						"area",
-						"frankfurt",
+						"frankfurt-am-main",
 						"directions"
 					],
 					"query": [
 						{
 							"key": "departure",
-							"value": "2018-05-07T10:15:30"
+							"value": "2018-08-31T17%3A06%3A37.897Z"
 						},
 						{
 							"key": "coordinates",
-							"value": "[[8.645333, 50.087314],[8.635897, 50.104172]]"
+							"value": "[[8.644231, 50.087102],[8.637313, 50.119479 ]]"
 						}
 					]
 				}
@@ -78,14 +78,14 @@
 				],
 				"body": {},
 				"url": {
-					"raw": "localhost:3000/area/frankfurt/stop/763067498",
+					"raw": "localhost:3000/area/frankfurt-am-main/stop/763067498",
 					"host": [
 						"localhost"
 					],
 					"port": "3000",
 					"path": [
 						"area",
-						"frankfurt",
+						"frankfurt-am-main",
 						"stop",
 						"763067498"
 					]

--- a/resources/overpass-api-query.txt
+++ b/resources/overpass-api-query.txt
@@ -1,7 +1,7 @@
 
 [out:xml][timeout:180];
 // get the specific search area
-{{geocodeArea:niederrad}}->.searchArea;
+area["name"="Niederrad"]->.searchArea;
 // get all ways that are accessible to pedestrians
 (
 	way["access"!~"no|private"](area.searchArea);

--- a/src/hiposfer/kamal/core.clj
+++ b/src/hiposfer/kamal/core.clj
@@ -15,7 +15,6 @@
             [taoensso.timbre :as timbre]
             [clojure.walk :as walk]
             [clojure.spec.alpha :as s]
-            [spec-tools.core :as st]
             [clojure.string :as str]
             [clojure.edn :as edn]))
 
@@ -33,8 +32,10 @@
   [m]
   (let [nets (filter (fn [[k]] (re-matches area-regex (name k))) m)]
     (for [[k v] nets]
-      (let [[_ id ext] (re-find area-regex (name k))]
-        (into {:area/id id} [[(keyword "area" (str/lower-case ext)) v]])))))
+      (let [[_ id ext] (re-find area-regex (name k))
+            area-name  (str/replace id "_" " ")]
+        (into {:area/name area-name}
+              [[(keyword "area" (str/lower-case ext)) v]])))))
 ;; (preprocess-env {:Frankfurt_am_Main_AREA_GTFS "foo"})
 
 (s/def ::USE_FAKE_NETWORK boolean?)

--- a/src/hiposfer/kamal/core.clj
+++ b/src/hiposfer/kamal/core.clj
@@ -58,7 +58,7 @@
         areas   (into {} (filter #(re-matches area-regex (name (key %)))) env)]
     (assert (s/valid? ::areas areas) (s/explain ::areas areas))
     (assert (s/valid? ::env sconfig) (s/explain ::env sconfig))
-    (merge (into {} server) {:networks (prepare-areas areas)})))
+    (merge sconfig {:networks (prepare-areas areas)})))
 
 (defn system
   "creates a complete system map using components and the provided

--- a/src/hiposfer/kamal/core.clj
+++ b/src/hiposfer/kamal/core.clj
@@ -20,19 +20,16 @@
             [clojure.string :as str]))
 
 ;; matches strings like SAARLAND_AREA_OSM
-(def area-regex #"^([A-Z0-9]+)_AREA_(OSM|GTFS|EDN)$")
+(def area-regex #"^(\w+)_AREA_(\w+)$")
 (defn- area-id [k] (second (re-find area-regex (name k))))
 
-;; TODO: we should check that the values are strings
-;; TODO: osm is mandatory, everything else is optional
 (defn- networks
-  "takes a map of enviroment variables and returns a sequence of
+  "takes a map of environment variables and returns a sequence of
   maps with the area env vars grouped. An extra key :area/id is
   added to each map for dynamic name processing"
   [envs]
   (let [nets (for [k (keys envs)
-                   :let [st (name k)]
-                   :when (re-matches area-regex st)]
+                   :when (re-matches area-regex (name k))]
                k)]
     (for [[id ks] (group-by area-id nets)]
      (conj (select-keys envs ks) [:area/id id]))))

--- a/src/hiposfer/kamal/core.clj
+++ b/src/hiposfer/kamal/core.clj
@@ -32,9 +32,10 @@
   [m]
   (let [nets (filter (fn [[k]] (re-matches area-regex (name k))) m)]
     (for [[k v] nets]
-      (let [[_ id ext] (re-find area-regex (name k))
-            area-name  (str/replace id "_" " ")]
-        (into {:area/name area-name}
+      (let [[_ aname ext] (re-find area-regex (name k))
+            id            (str/lower-case (str/replace aname "_" "-"))
+            area-name     (str/replace aname "_" " ")]
+        (into {:area/name area-name :area/id id}
               [[(keyword "area" (str/lower-case ext)) v]])))))
 ;; (preprocess-env {:Frankfurt_am_Main_AREA_GTFS "foo"})
 

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -21,9 +21,7 @@
   {:USE_FAKE_NETWORK false
    :JOIN_THREAD false
    :PORT 3000
-   ;:FREIBURG_AREA_GTFS "resources/freiburg.gtfs.zip"})
-   ;:FRANKFURT_AREA_GTFS "resources/frankfurt.gtfs.zip"})
-   :FRANKFURT_AREA_EDN "resources/frankfurt.edn.bz2"})
+   :FRANKFURT_AM_MAIN_AREA_EDN "resources/frankfurt_am_main.edn.gzip"})
 
 (defonce system nil)
 

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -44,10 +44,10 @@
   (alter-var-root #'system (fn [s] (when s (component/stop s)))))
 
 (defn- custom-printer
-  []
-  (expound/custom-printer {:show-valid-values? true
-                           :print-specs? false
-                           :theme :figwheel-theme}))
+  [explain-data]
+  (let [printer (expound/custom-printer {:show-valid-values? true
+                                         :print-specs? false})]
+    (printer explain-data)))
 
 (defn go!
   "Initializes the current development system and starts it running."

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -14,17 +14,16 @@
             [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha]
             [clojure.tools.namespace.repl :as repl]
-            [taoensso.timbre :as timbre]
-            [spec-tools.core :as st]))
+            [taoensso.timbre :as timbre]))
 
 (def env
   "a fake environment variables setting for development"
   {:USE_FAKE_NETWORK false
    :JOIN_THREAD false
    :PORT 3000
-   :SAARLAND_AREA_GTFS "resources/saarland.gtfs.zip"
-   :SAARLAND_AREA_OSM "resources/saarland.min.osm.bz2"
-   :SAARLAND_AREA_EDN "resources/saarland.edn.bz2"})
+   ;:FREIBURG_AREA_GTFS "resources/freiburg.gtfs.zip"})
+   ;:FRANKFURT_AREA_GTFS "resources/frankfurt.gtfs.zip"})
+   :FRANKFURT_AREA_EDN "resources/frankfurt.edn.bz2"})
 
 (defonce system nil)
 
@@ -32,7 +31,7 @@
   "Constructs the current development system."
   []
   (alter-var-root #'system
-    (constantly (core/system (st/conform! ::core/env env)))))
+    (constantly (core/system (core/prepare-env env)))))
 
 (defn start!
   "Starts the current development system."
@@ -46,14 +45,19 @@
   (timbre/debug "Stopping System\n")
   (alter-var-root #'system (fn [s] (when s (component/stop s)))))
 
+(defn- custom-printer
+  []
+  (expound/custom-printer {:show-valid-values? true
+                           :print-specs? false
+                           :theme :figwheel-theme}))
+
 (defn go!
   "Initializes the current development system and starts it running."
   []
   (stop!)
   (init!)
   (clojure.spec.test.alpha/instrument)
-  (set! s/*explain-out* (expound/custom-printer {:theme :figwheel-theme
-                                                 :print-specs? false}))
+  (alter-var-root #'s/*explain-out* (constantly custom-printer))
   (set! *warn-on-reflection* true)
   (set! *print-length* 100)
   (start!))

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -43,7 +43,7 @@
   (timbre/debug "Stopping System\n")
   (alter-var-root #'system (fn [s] (when s (component/stop s)))))
 
-(defn- custom-printer
+(defn custom-printer
   [explain-data]
   (let [printer (expound/custom-printer {:show-valid-values? true
                                          :print-specs? false})]

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -57,7 +57,7 @@
   (clojure.spec.test.alpha/instrument)
   (alter-var-root #'s/*explain-out* (constantly custom-printer))
   (set! *warn-on-reflection* true)
-  (set! *print-length* 100)
+  (set! *print-length* 50)
   (start!))
 
 (defn refresh!

--- a/src/hiposfer/kamal/gtfs.clj
+++ b/src/hiposfer/kamal/gtfs.clj
@@ -98,6 +98,7 @@
       (merge form {:required required}
                   (when unique {:unique unique})))))
 
+;; TODO: this is a bit outdated :(
 (defn- parse
   [raw]
   (let [content    (md/parse raw)

--- a/src/hiposfer/kamal/gtfs.clj
+++ b/src/hiposfer/kamal/gtfs.clj
@@ -1,0 +1,124 @@
+(ns hiposfer.kamal.gtfs
+  "parse the Markdown GTFS spec definition and returns it as Clojure data structures.
+
+  Uses several heuristics to guess how to interpret the data.
+
+  Useful to avoid monkey patching"
+  (:require [clojure.string :as str]
+            [markdown2clj.core :as md]
+            [clojure.pprint :as pprint]
+            [clojure.edn :as edn]))
+
+(def url "https://raw.githubusercontent.com/google/transit/master/gtfs/spec/en/reference.md")
+
+;; NOTE: we purposedly discard the edge case of several nested headers as
+;; it makes this function much more simpler
+(defn sections
+  [md]
+  (let [prev (volatile! (first (:document md)))]
+    (partition-by (fn [v] (if (:heading v)
+                            (vreset! prev v)
+                            (deref prev)))
+                  (:document md))))
+;; (sections content)
+
+(defn zipify
+  [section]
+  (let [table   (some :table-block section)
+        head    (some :table-head table)
+        body    (some :table-body table)
+        headers (->> (tree-seq coll? seq head)
+                     (filter string?)
+                     (map str/lower-case)
+                     (map #(str/replace % " " "-")) ;; otherwise not valid literal keyword
+                     (map keyword))
+        rows    (for [row (map :table-row body)]
+                  (for [cell row]
+                    (->> (tree-seq coll? seq cell)
+                         (filter map?)
+                         (filter :text)
+                         (map :text)
+                         (str/join ""))))]
+    (map #(zipmap %1 %2) (repeat headers) rows)))
+;; example
+;; (feed-files content)
+
+
+(defn- header [section] (-> section first :heading second :text))
+
+(def enum-edge-cases #{"wheelchair_boarding" "direction_id"
+                       "wheelchair_accessible" "timepoint"
+                       "payment_method" "transfers"
+                       "exact_times" "bikes_allowed"})
+
+(defn- enum?
+  [parent field]
+  (and (empty? (:field-name field))
+       (empty? (:required field))
+       (not (empty? (:details field)))
+       (or (str/ends-with? (:field-name parent) "_type")
+           (contains? enum-edge-cases
+                      (:field-name parent)))))
+
+(defn- enum-value
+  [text]
+  (if-let [[_ value description] (re-matches #"\* (\d) - (.*)" text)]
+    {:description description
+     :value (edn/read-string value)}
+    text))
+
+(defn- parse-enums
+  ([fields]
+   (parse-enums (rest fields) [] (first fields)))
+  ([fields result parent]
+   (cond
+     (enum? parent (first fields))
+     (recur (rest fields)
+            result
+            (update parent :values conj (enum-value (:details (first fields)))))
+
+     (some? (:values parent))
+     (recur (rest fields)
+            (conj result (update parent :values reverse))
+            (first fields))
+
+     (and (empty? fields) (nil? parent)) result
+
+     (empty? fields) (conj result parent)
+
+     :else
+     (recur (rest fields) (conj result parent) (first fields)))))
+
+(defn- tidy
+  [form]
+  (if (not (map? form)) form
+    (let [required (= (:required form) "Required")
+          details  (str/lower-case (or (:details form) (:defines form)))
+          unique   (str/includes? details "dataset unique")]
+      (merge form {:required required}
+                  (when unique {:unique unique})))))
+
+(defn- parse
+  [raw]
+  (let [content    (md/parse raw)
+        parts      (sections content)
+        feed-files (some #(when (= "Feed Files" (header %)) %) parts)
+        feed-data  (zipify feed-files)
+        files      (filter #(when (str/ends-with? (header %) ".txt") %)
+                           (sections content))
+        files-data (for [file files]
+                     {:filename (header file)
+                      :fields   (->> (zipify file)
+                                     (parse-enums)
+                                     (remove #(and (empty? (:field-name %))
+                                                   (empty? (:required %))))
+                                     (map tidy))})]
+    {:feed-files (map tidy feed-data)
+     :field-definitions files-data}))
+
+(defn -main
+  [out]
+  (spit out (with-out-str (pprint/pprint (parse (slurp url))))))
+
+;(parse (slurp url))
+;(-main "resources/gtfs/reference.edn")

--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -186,8 +186,11 @@
   (for [stop (map #(data/entity network (:e %))
                   (data/datoms network :aevt :stop/id))]
     (let [node (first (nearest-node network (:stop/location stop)))]
-      {:node/id (:node/id node)
-       :node/successors #{[:stop/id (:stop/id stop)]}})))
+      (if (not (some? node))
+        (throw (ex-info "stop didnt match to any known node in the OSM data"
+                        (into {} stop)))
+        {:node/id (:node/id node)
+         :node/successors #{[:stop/id (:stop/id stop)]}}))))
 
 ;; this reduced my test query from 30 seconds to 8 seconds
 (defn cache-stop-successors

--- a/src/hiposfer/kamal/libs/geometry.clj
+++ b/src/hiposfer/kamal/libs/geometry.clj
@@ -34,6 +34,24 @@
 ; (* (frepos/distance [2.33 48.87] [-122.4 37.8]) (/ 3440.069 6372))
 ; => 4831.502535634215 nauticals miles
 
+(def degree-len 110250) ;; meters
+
+;; taken from
+;; http://jonisalonen.com/2014/computing-distance-between-coordinates-can-be-simple-and-fast/
+(defn earth-distance
+  ([lon-1 lat-1 lon-2 lat-2]
+   (let [x (Math/toRadians (- lat-1 lat-2))
+         y (* (Math/toRadians (- lon-1 lon-2))
+              (Math/cos (Math/toRadians lat-1)))]
+     (Math/toDegrees (* degree-len (Math/sqrt (+ (Math/pow x 2)
+                                                 (Math/pow y 2)))))))
+  ([p1 p2]
+   (earth-distance (np/lon p1) (np/lat p1)
+                   (np/lon p2) (np/lat p2))))
+
+;(haversine [8.645333, 50.087314] [8.635897, 50.104172])
+;(earth-distance [8.645333, 50.087314] [8.635897, 50.104172])
+
 (defn euclidean-pow2
   "computes the squared euclidean distance between p1 and p2 being both of them
   {lat, lon} points. Use only if you interested in performance and not on the

--- a/src/hiposfer/kamal/libs/tool.clj
+++ b/src/hiposfer/kamal/libs/tool.clj
@@ -122,7 +122,7 @@
   [k v]
   (let [suffix (name k)
         ident  (keyword suffix "id")]
-    [k {:id (get v ident)}]))
+    [k {ident (get v ident)}]))
 
 (def gtfs-ns (set (vals gtfs/file-ns)))
 

--- a/src/hiposfer/kamal/libs/tool.clj
+++ b/src/hiposfer/kamal/libs/tool.clj
@@ -71,7 +71,8 @@
 (defn- stringify?
   "only stringifies java object which are not primities (java.lang...)"
   [^Object value]
-  (and (str/starts-with? (.getCanonicalName (.getClass ^Object value)) "java")
+  (and (some? value)
+       (str/starts-with? (.getCanonicalName (.getClass ^Object value)) "java")
        (not (str/starts-with? (.getCanonicalName (.getClass ^Object value)) "java.lang"))))
 
 (defn jsonista

--- a/src/hiposfer/kamal/parsers/edn.clj
+++ b/src/hiposfer/kamal/parsers/edn.clj
@@ -5,7 +5,7 @@
             [hiposfer.kamal.network.core :as network])
   (:import (java.time LocalDateTime DayOfWeek LocalDate ZoneId)
            (java.io PushbackReader InputStreamReader)
-           (org.apache.commons.compress.compressors.bzip2 BZip2CompressorInputStream)))
+           (java.util.zip GZIPOutputStream)))
 
 (def java-readers
   "java class to parsing function. Useful to deserialize things from EDN"
@@ -31,7 +31,7 @@
   Returns a Datascript Database"
   [filename]
   (with-open [stream (-> (io/input-stream filename)
-                         (BZip2CompressorInputStream.)
+                         (GZIPOutputStream.)
                          (InputStreamReader.)
                          (PushbackReader.))]
     (edn/read {:readers (merge data/data-readers local-readers)}

--- a/src/hiposfer/kamal/parsers/edn.clj
+++ b/src/hiposfer/kamal/parsers/edn.clj
@@ -5,7 +5,7 @@
             [hiposfer.kamal.network.core :as network])
   (:import (java.time LocalDateTime DayOfWeek LocalDate ZoneId)
            (java.io PushbackReader InputStreamReader)
-           (java.util.zip GZIPOutputStream)))
+           (java.util.zip GZIPInputStream)))
 
 (def java-readers
   "java class to parsing function. Useful to deserialize things from EDN"
@@ -31,7 +31,7 @@
   Returns a Datascript Database"
   [filename]
   (with-open [stream (-> (io/input-stream filename)
-                         (GZIPOutputStream.)
+                         (GZIPInputStream.)
                          (InputStreamReader.)
                          (PushbackReader.))]
     (edn/read {:readers (merge data/data-readers local-readers)}

--- a/src/hiposfer/kamal/parsers/osm.clj
+++ b/src/hiposfer/kamal/parsers/osm.clj
@@ -100,14 +100,13 @@
 ;; data is part of the OSM file. See README
 
 ;; TODO: deduplicate strings in ways name
-(defn datomize
+(defn datomize!
   "read an OSM file and transforms it into a network of {:graph :ways :points},
    such that the graph represent only the connected nodes, the points represent
    the shape of the connection and the ways are the metadata associated with
    the connections"
-  [filename] ;; read all elements into memory
-  (let [nodes&ways    (with-open [file-rdr (-> (io/input-stream filename)
-                                               (BZip2CompressorInputStream.))]
+  [input-stream] ;; read all elements into memory
+  (let [nodes&ways    (with-open [file-rdr input-stream]
                         (into [] (comp (map entries)
                                        (remove nil?))
                               (:content (xml/parse file-rdr))))

--- a/src/hiposfer/kamal/parsers/osm.clj
+++ b/src/hiposfer/kamal/parsers/osm.clj
@@ -1,8 +1,6 @@
 (ns hiposfer.kamal.parsers.osm
   (:require [clojure.data.xml :as xml]
-            [hiposfer.kamal.network.core :as network]
-            [clojure.java.io :as io])
-  (:import (org.apache.commons.compress.compressors.bzip2 BZip2CompressorInputStream)))
+            [hiposfer.kamal.network.core :as network]))
 
 ;;TODO: include routing attributes for penalties
 ;; bridge=yes      Also true/1/viaduct

--- a/src/hiposfer/kamal/preprocessor.clj
+++ b/src/hiposfer/kamal/preprocessor.clj
@@ -47,7 +47,7 @@
   "Script for preprocessing OSM and GTFS files into gzip files each with
   a Datascript EDN representation inside"
   [outdir]
-  (assert (not (nil? outdir)) "missing output file")
+  (assert (some? outdir)) "missing output file"
   (timbre/info "preprocessing OSM and GTFS files")
   (let [env    (walk/keywordize-keys (into {} (System/getenv)))
         areas  (into {} (filter #(re-matches core/area-regex (name (key %)))) env)]

--- a/src/hiposfer/kamal/preprocessor.clj
+++ b/src/hiposfer/kamal/preprocessor.clj
@@ -56,7 +56,8 @@
       (println "processing area:" (:area/name area))
       (let [db   (prepare-data area)
             ;; osm is mandatory, use its filename !!
-            path (str outdir (str/lower-case (:area/name area)) ".edn.gzip")]
+            path (str outdir (str/replace (str/lower-case (:area/name area)) " " "_")
+                             ".edn.gzip")]
         (with-open [w (-> (io/output-stream path)
                           (GZIPOutputStream.)
                           (io/writer))]

--- a/src/hiposfer/kamal/preprocessor.clj
+++ b/src/hiposfer/kamal/preprocessor.clj
@@ -51,7 +51,7 @@
   (timbre/info "preprocessing OSM and GTFS files")
   (let [env    (walk/keywordize-keys (into {} (System/getenv)))
         areas  (into {} (filter #(re-matches core/area-regex (name (key %)))) env)]
-    (assert (s/valid? ::env areas) (s/explain ::env areas))
+    (assert (s/valid? ::env areas) (s/explain-str ::env areas))
     (doseq [area (core/prepare-areas areas)]
       (println "processing area:" (:area/name area))
       (let [db   (prepare-data area)

--- a/src/hiposfer/kamal/preprocessor.clj
+++ b/src/hiposfer/kamal/preprocessor.clj
@@ -47,7 +47,7 @@
   "Script for preprocessing OSM and GTFS files into gzip files each with
   a Datascript EDN representation inside"
   [outdir]
-  (assert (some? outdir)) "missing output file"
+  (assert (some? outdir) "missing output file")
   (timbre/info "preprocessing OSM and GTFS files")
   (let [env    (walk/keywordize-keys (into {} (System/getenv)))
         areas  (into {} (filter #(re-matches core/area-regex (name (key %)))) env)]

--- a/src/hiposfer/kamal/preprocessor.clj
+++ b/src/hiposfer/kamal/preprocessor.clj
@@ -22,13 +22,13 @@
 
 (defn- prepare-data
   [area]
-  (let [human-id (str/replace (:area/id area) "_" " ")
-        query    (str/replace (slurp "resources/overpass-api-query.txt")
-                              "Niederrad"
-                              human-id)
-        url      (str "http://overpass-api.de/api/interpreter?data="
-                      (URLEncoder/encode query "UTF-8"))
-        conn     (. ^URL (io/as-url url) (openConnection))]
+  (let [area-name (str/replace (:area/id area) "_" " ")
+        query     (str/replace (slurp "resources/overpass-api-query.txt")
+                               "Niederrad"
+                               area-name)
+        url       (str "http://overpass-api.de/api/interpreter?data="
+                       (URLEncoder/encode query "UTF-8"))
+        conn      (. ^URL (io/as-url url) (openConnection))]
     ;; progressively build up the network from the pieces
     (with-open [z (-> (io/input-stream (:area/gtfs area))
                       (ZipInputStream.))]

--- a/src/hiposfer/kamal/preprocessor.clj
+++ b/src/hiposfer/kamal/preprocessor.clj
@@ -22,10 +22,9 @@
 
 (defn fetch-osm
   [area]
-  (let [area-name (str/replace (:area/id area) "_" " ")
-        query     (str/replace (slurp "resources/overpass-api-query.txt")
+  (let [query     (str/replace (slurp "resources/overpass-api-query.txt")
                                "Niederrad"
-                               area-name)
+                               (:area/name area))
         url       (str "http://overpass-api.de/api/interpreter?data="
                        (URLEncoder/encode query "UTF-8"))
         conn      (. ^URL (io/as-url url) (openConnection))
@@ -54,10 +53,10 @@
         areas  (into {} (filter #(re-matches core/area-regex (name (key %)))) env)]
     (assert (s/valid? ::env areas) (s/explain ::env areas))
     (doseq [area (core/prepare-areas areas)]
-      (println "processing area:" (:area/id area))
+      (println "processing area:" (:area/name area))
       (let [db   (prepare-data area)
             ;; osm is mandatory, use its filename !!
-            path (str outdir (str/lower-case (:area/id area)) ".edn.gzip")]
+            path (str outdir (str/lower-case (:area/name area)) ".edn.gzip")]
         (with-open [w (-> (io/output-stream path)
                           (GZIPOutputStream.)
                           (io/writer))]

--- a/src/hiposfer/kamal/services/routing/core.clj
+++ b/src/hiposfer/kamal/services/routing/core.clj
@@ -62,21 +62,10 @@
 (defn network
   "builds a datascript in-memory db and conj's it into the passed agent"
   [area]
-  (if (:area/edn area)
-    ;; re-build the network from the file
-    (as-> (edn/parse (:area/edn area)) $
-          (data/db-with $ [area]) ;; add the area as transaction
-          (data/conn-from-db $))
-    ;; progressively build up the network from the pieces
-    (with-open [z (-> (io/input-stream (:area/gtfs area))
-                      (ZipInputStream.))]
-      (as-> (data/empty-db schema) $
-            (data/db-with $ (osm/datomize (:area/osm area)))
-            (data/db-with $ (gtfs/datomize! z))
-            (data/db-with $ (fastq/link-stops $))
-            (data/db-with $ (fastq/cache-stop-successors $))
-            (data/db-with $ [area]) ;; add the area as transaction
-            (data/conn-from-db $)))))
+  ;; re-build the network from the file
+  (as-> (edn/parse (:area/edn area)) $
+        (data/db-with $ [area]) ;; add the area as transaction
+        (data/conn-from-db $)))
 
 (defn pedestrian-graph
   "builds a datascript in-memory db and returns it. Only valid for

--- a/src/hiposfer/kamal/services/routing/core.clj
+++ b/src/hiposfer/kamal/services/routing/core.clj
@@ -19,18 +19,18 @@
 ;; This is a hack !! but it works :)
 ;; Thanks datascript
 
-(def schema {:area/id         {:db.unique :db.unique/identity}
+(def schema {:area/name       {:db.unique :db.unique/identity}
              ;; Open Street Map - entities
              :node/id         {:db.unique :db.unique/identity}
              :node/location   {:db/index true}
              :node/successors {:db.type        :db.type/ref
                                :db.cardinality :db.cardinality/many
-                               :db/index true}
+                               :db/index       true}
 
              :way/id          {:db.unique :db.unique/identity}
              :way/nodes       {:db.type        :db.type/ref
                                :db.cardinality :db.cardinality/many
-                               :db/index true}
+                               :db/index       true}
 
              ;; General Transfer Feed Specification - entities
              :trip/id         {:db.unique :db.unique/identity}
@@ -45,14 +45,14 @@
              :route/agency    {:db/type :db.type/ref}
 
              :stop/id         {:db.unique :db.unique/identity}
-             :stop/successors {:db.type :db.type/ref
+             :stop/successors {:db.type        :db.type/ref
                                :db.cardinality :db.cardinality/many}
              :stop/location   {:db/index true}
 
-             :stop_times/trip  {:db/type :db.type/ref
-                                :db/index true}
-             :stop_times/stop  {:db/type :db.type/ref
-                                :db/index true}})
+             :stop_times/trip {:db/type  :db.type/ref
+                               :db/index true}
+             :stop_times/stop {:db/type  :db.type/ref
+                               :db/index true}})
 
 (defn network
   "builds a datascript in-memory db and conj's it into the passed agent"

--- a/src/hiposfer/kamal/services/routing/core.clj
+++ b/src/hiposfer/kamal/services/routing/core.clj
@@ -1,16 +1,11 @@
 (ns hiposfer.kamal.services.routing.core
-  (:require [hiposfer.kamal.parsers.osm :as osm]
-            [hiposfer.kamal.network.generators :as ng]
+  (:require [hiposfer.kamal.network.generators :as ng]
             [clojure.test.check.generators :as gen]
-            [hiposfer.kamal.parsers.gtfs.core :as gtfs]
             [datascript.core :as data]
             [com.stuartsierra.component :as component]
             [hiposfer.kamal.network.algorithms.core :as alg]
-            [hiposfer.kamal.libs.fastq :as fastq]
             [taoensso.timbre :as timbre]
-            [clojure.java.io :as io]
-            [hiposfer.kamal.parsers.edn :as edn])
-  (:import (java.util.zip ZipInputStream)))
+            [hiposfer.kamal.parsers.edn :as edn]))
 
 ;; NOTE: we use :db/index true to replace the lack of :VAET index in datascript
 ;; This is for performance. In lots of cases we want to lookup back-references
@@ -63,9 +58,7 @@
   "builds a datascript in-memory db and conj's it into the passed agent"
   [area]
   ;; re-build the network from the file
-  (as-> (edn/parse (:area/edn area)) $
-        (data/db-with $ [area]) ;; add the area as transaction
-        (data/conn-from-db $)))
+  (data/conn-from-db (edn/parse (:area/edn area))))
 
 (defn pedestrian-graph
   "builds a datascript in-memory db and returns it. Only valid for

--- a/src/hiposfer/kamal/services/routing/core.clj
+++ b/src/hiposfer/kamal/services/routing/core.clj
@@ -19,7 +19,7 @@
 ;; This is a hack !! but it works :)
 ;; Thanks datascript
 
-(def schema {:area/name       {:db.unique :db.unique/identity}
+(def schema {:area/id         {:db.unique :db.unique/identity}
              ;; Open Street Map - entities
              :node/id         {:db.unique :db.unique/identity}
              :node/location   {:db/index true}

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -159,9 +159,9 @@
         {:step/arrive (+ start arrives)}
         {:step/departure (+ start departs)})
       (when (= "transit" mode)
-        (if (= "exit vehicle" (man :maneuver/type))
+        (if (= "exit vehicle" (:maneuver/type man))
           (tool/gtfs-resource (:end (val (first piece))))
-          (tool/gtfs-resource (:start (val (first next-piece)))))))))
+          (tool/gtfs-resource (:start (val (first piece)))))))))
 
 (defn- route-steps
   "returns a route-steps vector or an empty vector if no steps are needed"

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -18,7 +18,7 @@
             [hiposfer.kamal.libs.fastq :as fastq]
             [datascript.core :as data]
             [hiposfer.kamal.libs.tool :as tool])
-  (:import (java.time LocalDateTime Duration LocalTime)))
+  (:import (java.time LocalDateTime Duration LocalTime LocalDate)))
 
 ;; https://www.mapbox.com/api-documentation/#stepmaneuver-object
 (def bearing-turns
@@ -55,8 +55,8 @@
   "returns a human readable version of the maneuver to perform"
   [network result piece next-piece]
   (let [context  (transit/context network piece)
-        modifier (:modifier result)
-        maneuver (:type result)
+        modifier (:maneuver/modifier result)
+        maneuver (:maneuver/type result)
         name     (transit/name context)]
     (case maneuver
       ;; walking normally
@@ -130,32 +130,33 @@
                                        (location (key (first next-piece))))
         angle        (mod (+ 360 (- post-bearing pre-bearing)) 360)
         _type        (maneuver-type network prev-piece piece next-piece)
-        result       (merge {:bearing_before pre-bearing
-                             :bearing_after  post-bearing
-                             :type _type}
+        result       (merge {:maneuver/bearing_before pre-bearing
+                             :maneuver/bearing_after  post-bearing
+                             :maneuver/type _type}
                        (when (= _type "turn")
-                         {:modifier (modifier angle _type)}))]
-    (assoc result :instruction (instruction network result piece next-piece))))
+                         {:maneuver/modifier (modifier angle _type)}))]
+    (assoc result :maneuver/instruction (instruction network result piece next-piece))))
 
 ;https://www.mapbox.com/api-documentation/#routestep-object
 (defn- step ;; piece => [trace ...]
   "includes one StepManeuver object and travel to the following RouteStep"
-  [network prev-piece piece next-piece]
+  [^LocalDateTime start network prev-piece piece next-piece]
   (let [context (transit/context network piece)
         line    (linestring (map key (concat piece [(first next-piece)])))
         man     (maneuver network prev-piece piece next-piece)
-        mode    (if (transit/stop? context) "transit" "walking")]
-    (merge
-      {:mode     mode
-       :maneuver man
-       :distance (geometry/arc-length (:coordinates line))
-       :duration (- (np/cost (val (first next-piece)))
-                    (np/cost (val (first piece))))
-       :geometry line}
-      (when (some? (transit/name context))
-        {:name (transit/name context)})
-      (when (= "notification" (man :type))
-        {:arrival_time (np/cost (val (first piece)))})
+        mode    (if (transit/stop? context) "transit" "walking")
+        departs (np/cost (val (first piece)))
+        arrives (np/cost (val (first next-piece)))]
+    (merge man
+      {:step/mode     mode
+       :step/distance (geometry/arc-length (:coordinates line))
+       :step/duration (Duration/ofSeconds (- arrives departs))
+       :step/geometry line}
+      (when (not-empty (transit/name context))
+        {:step/name (transit/name context)})
+      (if (= "arrive" (:type man))
+        {:step/arrive (. start (plusSeconds arrives))}
+        {:step/departure (. start (plusSeconds departs))})
       (when (= "transit" mode)
         (if (= "exit vehicle" (man :type))
           (tool/gtfs-resource (:end (val (first piece))))
@@ -163,27 +164,32 @@
 
 (defn- route-steps
   "returns a route-steps vector or an empty vector if no steps are needed"
-  [network pieces] ;; piece => [[trace via] ...]
+  [network pieces midnight] ;; piece => [[trace via] ...]
   (let [start     [(first pieces)] ;; add depart and arrival pieces into the calculation
         end       (repeat 2 [(last (last pieces))]) ;; use only the last point as end - not the entire piece
         extended  (concat start pieces end)]
-    (map step (repeat network) extended (rest extended) (rest (rest extended)))))
+    (map step (repeat midnight)
+              (repeat network)
+              extended
+              (rest extended)
+              (rest (rest extended)))))
 
 ;https://www.mapbox.com/api-documentation/#route-object
 (defn- route
   "a route from the first to the last waypoint. Only two waypoints
   are currently supported"
-  [network rtrail]
+  [network rtrail midnight]
   (let [trail  (rseq (into [] rtrail))]
     (if (= (count trail) 1) ;; a single trace is returned for src = dst
-      {:distance 0 :duration 0 :steps [] :summary "" :annotation []}
+      {:route/distance 0 :route/duration 0 :route/steps []}
       (let [previous    (volatile! (first trail))
             pieces      (partition-by #(transit/name (transit/context! network % previous))
-                                       trail)]
-        {:distance   (geometry/arc-length (:coordinates (linestring (map key trail))))
-         :duration   (- (np/cost (val (last trail)))
-                        (np/cost (val (first trail))))
-         :steps      (route-steps network pieces)}))))
+                                       trail)
+            departs     (np/cost (val (first trail)))
+            arrives     (np/cost (val (last trail)))]
+        {:route/distance (geometry/arc-length (:coordinates (linestring (map key trail))))
+         :route/duration (Duration/ofSeconds (- arrives departs))
+         :route/steps    (route-steps network pieces midnight)}))))
 
 ;; for the time being we only care about the coordinates of start and end
 ;; but looking into the future it is good to make like this such that we
@@ -197,30 +203,31 @@
    Example:
    (direction network :coordinates [{:lon 1 :lat 2} {:lon 3 :lat 4}]"
   [network params]
+  (println params)
   (let [{:keys [coordinates ^LocalDateTime departure]} params
-        date       (.toLocalDate departure)
+        date       (. departure (toLocalDate))
         trips      (fastq/day-trips network date)
         start      (Duration/between (LocalTime/MIDNIGHT)
-                                     (.toLocalTime departure))
+                                     (. departure (toLocalTime)))
         src        (first (fastq/nearest-node network (first coordinates)))
         dst        (first (fastq/nearest-node network (last coordinates)))
        ; both start and dst should be found since we checked that before
-        traversal  (alg/dijkstra network #{[src (.getSeconds start)]}
+        traversal  (alg/dijkstra network #{[src (. start (getSeconds))]}
                                  {:value-by   #(transit/timetable-duration network trips %1 %2)
                                   :successors transit/successors
                                   :comparator transit/by-cost})
         rtrail     (alg/shortest-path dst traversal)]
-    (if (some? rtrail)
-      {:code      "Ok"
-       :uuid      (data/squuid)
-       :waypoints [{:name     (str (some :way/name (fastq/node-ways network src)))
-                    :location (->coordinates (:node/location src))}
-                   {:name     (str (some :way/name (fastq/node-ways network dst)))
-                    :location (->coordinates (:node/location dst))}]
-       :route     (route network rtrail)}
-      {:code "NoRoute"
-       :message "There was no route found for the given coordinates. Check for
-                       impossible routes (e.g. routes over oceans without ferry connections)."})))
+    (when (some? rtrail)
+      (merge
+        {:route/uuid      (data/squuid)
+         :route/waypoints
+         [{:waypoint/name     (some (comp not-empty :way/name)
+                                    (fastq/node-ways network src))
+           :waypoint/location (->coordinates (location src))}
+          {:waypoint/name     (some (comp not-empty :way/name)
+                                    (fastq/node-ways network dst))
+           :waypoint/location (->coordinates (location dst))}]}
+        (route network rtrail (. date (atStartOfDay)))))))
 
 ;(time
 ;  (direction @(first @(:networks (:router hiposfer.kamal.dev/system)))

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -203,7 +203,6 @@
    Example:
    (direction network :coordinates [{:lon 1 :lat 2} {:lon 3 :lat 4}]"
   [network params]
-  (println params)
   (let [{:keys [coordinates ^LocalDateTime departure]} params
         date       (. departure (toLocalDate))
         trips      (fastq/day-trips network date)

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -218,8 +218,8 @@
         rtrail     (alg/shortest-path dst traversal)]
     (when (some? rtrail)
       (merge
-        {:route/uuid      (data/squuid)
-         :route/waypoints
+        {:directions/uuid      (data/squuid)
+         :directions/waypoints
          [{:waypoint/name     (some (comp not-empty :way/name)
                                     (fastq/node-ways network src))
            :waypoint/location (->coordinates (location src))}

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -181,15 +181,15 @@
   [network rtrail midnight]
   (let [trail  (rseq (into [] rtrail))]
     (if (= (count trail) 1) ;; a single trace is returned for src = dst
-      {:route/distance 0 :route/duration 0 :route/steps []}
+      {:directions/distance 0 :directions/duration 0 :directions/steps []}
       (let [previous    (volatile! (first trail))
             pieces      (partition-by #(transit/name (transit/context! network % previous))
                                        trail)
             departs     (np/cost (val (first trail)))
             arrives     (np/cost (val (last trail)))]
-        {:route/distance (geometry/arc-length (:coordinates (linestring (map key trail))))
-         :route/duration (Duration/ofSeconds (- arrives departs))
-         :route/steps    (route-steps network pieces midnight)}))))
+        {:directions/distance (geometry/arc-length (:coordinates (linestring (map key trail))))
+         :directions/duration (Duration/ofSeconds (- arrives departs))
+         :directions/steps    (route-steps network pieces midnight)}))))
 
 ;; for the time being we only care about the coordinates of start and end
 ;; but looking into the future it is good to make like this such that we

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -74,7 +74,7 @@
         (str "Continue on " id))
 
       "notification"
-      (let [tend    (:start (val (first next-piece)))
+      (let [tend    (:start (val (first piece)))
             trip    (:stop_times/trip tend)
             route   (:trip/route trip)
             vehicle (transit/route-types (:route/type route))
@@ -155,11 +155,11 @@
        :step/geometry line}
       (when (not-empty (transit/name context))
         {:step/name (transit/name context)})
-      (if (= "arrive" (:type man))
+      (if (= "arrive" (:maneuver/type man))
         {:step/arrive (+ start arrives)}
         {:step/departure (+ start departs)})
       (when (= "transit" mode)
-        (if (= "exit vehicle" (man :type))
+        (if (= "exit vehicle" (man :maneuver/type))
           (tool/gtfs-resource (:end (val (first piece))))
           (tool/gtfs-resource (:start (val (first next-piece)))))))))
 

--- a/src/hiposfer/kamal/services/routing/transit.clj
+++ b/src/hiposfer/kamal/services/routing/transit.clj
@@ -22,10 +22,10 @@
    7 "Funicular"}); Any rail system designed for steep inclines.})
 
 (defn- walk-time [src dst]
-  (/ (geometry/haversine (or (:node/location src)
-                             (:stop/location src))
-                         (or (:node/location dst)
-                             (:stop/location dst)))
+  (/ (geometry/earth-distance (or (:node/location src)
+                                  (:stop/location src))
+                              (or (:node/location dst)
+                                  (:stop/location dst)))
      osm/walking-speed))
 
 (defn duration
@@ -55,7 +55,6 @@
 (defn node? [e] (:node/id e))
 (defn way? [e] (:way/id e))
 (defn stop? [e] (:stop/id e))
-(defn stop-times? [e] (:stop_times/trip e))
 (defn trip-step? [o] (instance? TripStep o))
 
 (defn name
@@ -123,7 +122,7 @@
 (defn timetable-duration
   "provides routing calculations using both GTFS feed and OSM nodes. Returns
   a Long for walking parts and a TripStep for GTFS related ones."
-  [network trips dst trail]
+  [network stop-times dst trail]
   (let [[src value] (first trail)
         now         (np/cost value)]
     (cond
@@ -137,7 +136,7 @@
       ;; the user is trying to get into a vehicle. We need to find the next
       ;; coming trip
       (and (stop? src) (stop? dst) (not (trip-step? value)))
-      (let [[st1 st2] (fastq/find-trip network trips src dst now)]
+      (let [[st1 st2] (fastq/find-trip network stop-times src dst now)]
         (when (some? st2) ;; nil if no trip was found
           ;(println {:src (:stop/name src)
           ;          :dst (:stop/name dst)

--- a/src/hiposfer/kamal/services/webserver/core.clj
+++ b/src/hiposfer/kamal/services/webserver/core.clj
@@ -9,7 +9,8 @@
             [ring.middleware.json :as json]
             [ring.util.http-response :as code]
             [ring.middleware.accept :as accept]
-            [hiposfer.kamal.libs.tool :as tool])
+            [hiposfer.kamal.libs.tool :as tool]
+            [clojure.walk :as walk])
   (:import (org.eclipse.jetty.server Server)))
 
 (defn- inject-networks
@@ -30,7 +31,7 @@
       (if (string? (response :body))
         response
         (case (:mime (:accept request))
-          "application/json" (update response :body tool/json-namespace)
+          "application/json" (update response :body #(walk/postwalk tool/jsonista %))
           "application/edn" (update response :body pr-str))))))
 
 ;; --------

--- a/src/hiposfer/kamal/services/webserver/handlers.clj
+++ b/src/hiposfer/kamal/services/webserver/handlers.clj
@@ -27,7 +27,7 @@
   [network params]
   (for [coord (:coordinates params)
         :let [node (:node/location (first (fastq/nearest-node network coord)))]
-        :when (not (nil? node))
+        :when (some? node)
         :let [dist (geometry/haversine coord node)]
         :when (< dist max-distance)]
     coord))

--- a/src/hiposfer/kamal/services/webserver/handlers.clj
+++ b/src/hiposfer/kamal/services/webserver/handlers.clj
@@ -19,7 +19,7 @@
   "returns a network whose bounding box contains all points"
   [conns params]
   (when-let [conn (first conns)]
-    (if (not (some? (data/entity @conn [:area/name (:area params)])))
+    (if (not (some? (data/entity @conn [:area/id (:area params)])))
       (recur (rest conns) params)
       @conn)))
 
@@ -77,8 +77,7 @@
                     (into {} (data/entity @conn id))))]
     (code/ok areas)))
 
-(def directions-coercer {:area        #(str/replace % "_" " ")
-                         :coordinates edn/read-string
+(def directions-coercer {:coordinates edn/read-string
                          :departure   #(ZonedDateTime/parse %)})
 
 (defn- get-directions

--- a/src/hiposfer/kamal/services/webserver/handlers.clj
+++ b/src/hiposfer/kamal/services/webserver/handlers.clj
@@ -77,7 +77,7 @@
                     (into {} (data/entity @conn id))))]
     (code/ok areas)))
 
-(def directions-coercer {:area        str/upper-case
+(def directions-coercer {:area        #(str/replace % "_" " ")
                          :coordinates edn/read-string
                          :departure   #(LocalDateTime/parse %)})
 
@@ -129,11 +129,11 @@
 ;                    [6.905707,49.398459])
 
 ;(time
-;  (dir/direction @(first @(:networks (:router hiposfer.kamal.dev/system)))
-;                 {:coordinates [[8.645333, 50.087314]
-;                                [8.635897, 50.104172]]
-;                               :departure (LocalDateTime/parse "2018-05-07T10:15:30")
-;                  :steps true}))
+;  (direction @(first @(:networks (:router hiposfer.kamal.dev/system)))
+;             {:coordinates [[8.645333, 50.087314]
+;                            [8.635897, 50.104172]]
+;              :departure (ZonedDateTime/parse "2018-05-07T10:15:30+02:00")
+;              :steps true}))
 
 ;(data/q '[:find ?id .
 ;          :where [_ :trip/id ?id]]

--- a/src/hiposfer/kamal/services/webserver/handlers.clj
+++ b/src/hiposfer/kamal/services/webserver/handlers.clj
@@ -117,7 +117,7 @@
     (api/GET "/area/:area/directions" request
       (get-directions (preprocess request ::dirspecs/params directions-coercer)))
     (api/GET "/area/:area/:name/:id" request
-      (get-resource (preprocess request ::resource/params {:area str/upper-case})))
+      (get-resource (preprocess request ::resource/params {:area #(str/replace % "_" " ")})))
     ;; TODO: implement some persistency for user suggestions
     ;; (api/PUT "/area/:area/suggestions" request
     ;;  (put-suggestions (preprocess request ::dirspecs/params directions-coercer)))

--- a/src/hiposfer/kamal/services/webserver/handlers.clj
+++ b/src/hiposfer/kamal/services/webserver/handlers.clj
@@ -69,10 +69,13 @@
 
 (defn- get-area
   [request]
-  (let [regions    (:kamal/networks request)
-        ids        (for [conn regions]
-                     {:area/id (data/q '[:find ?id . :where [_ :area/id ?id]] @conn)})]
-    (code/ok ids)))
+  (let [regions (:kamal/networks request)
+        areas   (for [conn regions]
+                  (let [id (data/q '[:find ?area .
+                                     :where [?area :area/id]]
+                                   @conn)]
+                    (into {} (data/entity @conn id))))]
+    (code/ok areas)))
 
 (def directions-coercer {:area        str/upper-case
                          :coordinates edn/read-string

--- a/src/hiposfer/kamal/services/webserver/handlers.clj
+++ b/src/hiposfer/kamal/services/webserver/handlers.clj
@@ -19,7 +19,7 @@
   "returns a network whose bounding box contains all points"
   [conns params]
   (when-let [conn (first conns)]
-    (if (not (some? (data/entity @conn [:area/id (:area params)])))
+    (if (not (some? (data/entity @conn [:area/name (:area params)])))
       (recur (rest conns) params)
       @conn)))
 
@@ -72,7 +72,7 @@
   (let [regions (:kamal/networks request)
         areas   (for [conn regions]
                   (let [id (data/q '[:find ?area .
-                                     :where [?area :area/id]]
+                                     :where [?area :area/name]]
                                    @conn)]
                     (into {} (data/entity @conn id))))]
     (code/ok areas)))
@@ -138,4 +138,3 @@
 ;(data/q '[:find ?id .
 ;          :where [_ :trip/id ?id]]
 ;         @(first @(:networks (:router hiposfer.kamal.dev/system))))
-

--- a/src/hiposfer/kamal/services/webserver/handlers.clj
+++ b/src/hiposfer/kamal/services/webserver/handlers.clj
@@ -11,7 +11,7 @@
             [clojure.edn :as edn]
             [hiposfer.kamal.libs.tool :as tool]
             [clojure.string :as str])
-  (:import (java.time LocalDateTime)))
+  (:import (java.time ZonedDateTime)))
 
 (def max-distance 1000) ;; meters
 
@@ -79,7 +79,7 @@
 
 (def directions-coercer {:area        #(str/replace % "_" " ")
                          :coordinates edn/read-string
-                         :departure   #(LocalDateTime/parse %)})
+                         :departure   #(ZonedDateTime/parse %)})
 
 (defn- get-directions
   [request]

--- a/src/hiposfer/kamal/specs/directions.clj
+++ b/src/hiposfer/kamal/specs/directions.clj
@@ -21,7 +21,7 @@
 
 (s/def :step/name     ::name)
 (s/def :step/mode     #{"transit" "walking"})
-(s/def :step/distance pos?)
+(s/def :step/distance #(not (neg? %)))
 (s/def :step/duration (s/and nat-int? pos?))
 (s/def :step/departure (s/and nat-int? pos?))
 (s/def :step/geometry   ::geojson/linestring)

--- a/src/hiposfer/kamal/specs/directions.clj
+++ b/src/hiposfer/kamal/specs/directions.clj
@@ -51,7 +51,7 @@
 (s/def ::waypoint         (s/keys :req [:waypoint/name :waypoint/location]))
 
 (s/def :directions/steps     (s/coll-of ::step :kind sequential?))
-(s/def :directions/distance  pos?)
+(s/def :directions/distance  #(not (neg? %)))
 (s/def :directions/waypoints (s/coll-of ::waypoint :kind sequential? :min-count 2))
 (s/def :route/uuid           uuid?)
 

--- a/src/hiposfer/kamal/specs/directions.clj
+++ b/src/hiposfer/kamal/specs/directions.clj
@@ -22,7 +22,7 @@
 (s/def :step/name     ::name)
 (s/def :step/mode     #{"transit" "walking"})
 (s/def :step/distance #(not (neg? %)))
-(s/def :step/duration (s/and nat-int? pos?))
+(s/def :step/duration (s/and nat-int? #(not (neg? %))))
 (s/def :step/departure (s/and nat-int? pos?))
 (s/def :step/geometry   ::geojson/linestring)
 

--- a/src/hiposfer/kamal/specs/directions.clj
+++ b/src/hiposfer/kamal/specs/directions.clj
@@ -25,6 +25,7 @@
 (s/def :step/mode     #{"transit" "walking"})
 (s/def :step/distance ::positive)
 (s/def :step/duration #(instance? Duration %))
+(s/def :step/departure #(instance? LocalDateTime %))
 (s/def :step/geometry   ::geojson/linestring)
 
 (s/def :maneuver/instruction    (s/and string? not-empty))

--- a/src/hiposfer/kamal/specs/directions.clj
+++ b/src/hiposfer/kamal/specs/directions.clj
@@ -12,8 +12,8 @@
 (s/def ::bearing     (s/and spec/number? #(<= 0 % 360)))
 
 ;;TODO this is a copy/paste of the gtfs spec but it gets the job done
-(s/def :stop_times/stop ::res/resource)
-(s/def :stop_times/trip ::res/resource)
+(s/def :stop_times/stop ::res/reference)
+(s/def :stop_times/trip ::res/reference)
 (s/def :stop_times/sequence spec/integer?)
 (s/def :stop_times/arrival_time nat-int?)
 (s/def :stop_times/departure_time nat-int?)

--- a/src/hiposfer/kamal/specs/directions.clj
+++ b/src/hiposfer/kamal/specs/directions.clj
@@ -51,15 +51,15 @@
 (s/def :waypoint/location :hiposfer.geojson.specs.point/coordinates)
 (s/def ::waypoint         (s/keys :req [:waypoint/name :waypoint/location]))
 
-(s/def :route/steps     (s/coll-of ::step :kind sequential?))
-(s/def :route/distance  ::positive)
-(s/def :route/waypoints (s/coll-of ::waypoint :kind sequential? :min-count 2))
+(s/def :directions/steps     (s/coll-of ::step :kind sequential?))
+(s/def :directions/distance  ::positive)
+(s/def :directions/waypoints (s/coll-of ::waypoint :kind sequential? :min-count 2))
 (s/def :route/uuid      uuid?)
 
-(s/def ::route     (s/nilable (s/keys :req- [:route/waypoints
-                                             :route/distance
-                                             :route/duration
-                                             :route/steps])))
+(s/def ::directions     (s/nilable (s/keys :req [:directions/waypoints
+                                                 :directions/distance
+                                                 :directions/duration
+                                                 :directions/steps])))
 
 ;;;;;;;;;;;;;;;;;;;;; REQUEST
 

--- a/src/hiposfer/kamal/specs/resources.clj
+++ b/src/hiposfer/kamal/specs/resources.clj
@@ -10,7 +10,7 @@
                          :when (contains? v :db.unique)]
                      (namespace k))))
 
-(s/def ::resource (s/keys :req-un [::id]))
+(s/def ::reference (s/map-of keyword? ::id :count 1)) ;; only the ref itself, no extra info
 
 ;;;; REQUEST
 

--- a/test/hiposfer/kamal/network/benchmark.clj
+++ b/test/hiposfer/kamal/network/benchmark.clj
@@ -34,7 +34,7 @@
 
 (def network (delay
                  (time
-                   (let [data (osm/datomize "resources/saarland.min.osm.bz2")
+                   (let [data (osm/datomize! "resources/saarland.min.osm.bz2")
                          conn (data/create-conn router/schema)]
                      (data/transact! conn data)
                      conn))))

--- a/test/hiposfer/kamal/network/benchmark.clj
+++ b/test/hiposfer/kamal/network/benchmark.clj
@@ -34,7 +34,7 @@
 
 (def network (delay
                  (time
-                   (let [data (osm/datomize! "resources/saarland.min.osm.bz2")
+                   (let [data (osm/datomize! "resources/frankfurt_am_main.edn.gzip")
                          conn (data/create-conn router/schema)]
                      (data/transact! conn data)
                      conn))))

--- a/test/hiposfer/kamal/network/benchmark.clj
+++ b/test/hiposfer/kamal/network/benchmark.clj
@@ -32,7 +32,7 @@
         (alg/shortest-path dst coll))
       :os :runtime :verbose)))
 
-(def network (delay (time (preprocessor/fetch-osm {:area/id "Frankfurt_am_Main"}))))
+(def network (delay (time (preprocessor/fetch-osm {:area/name "Frankfurt am Main"}))))
 
 ;;(type @network) ;; force read
 

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -187,7 +187,7 @@
 (def network (delay (time (router/network {:area/edn "resources/frankfurt_am_main.edn.gzip"}))))
 
 (defspec routing-directions
-  10; tries -> expensive test
+  20; tries -> expensive test
   (let [graph    (deref (deref network)) ;; delay atom
         nodes    (alg/nodes graph)
         gc       (count nodes)]
@@ -197,7 +197,7 @@
             depart   (gen/generate (s/gen ::dataspecs/departure))
             args     {:coordinates [src dst] :departure depart :steps true}
             response (future (dir/direction graph args))
-            result   (deref response 5000 ::timeout)]
+            result   (deref response 3500 ::timeout)]
         (when (= result ::timeout)
           (println "timeout"))
         (is (or (= result ::timeout)

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -175,11 +175,11 @@
 (defspec generative-directions
   100; tries
   (prop/for-all [i (gen/large-integer* {:min 10 :max 20})]
-                (let [graph   @(router/pedestrian-graph {:SIZE i})
-                      request  (gen/generate (s/gen ::dataspecs/params))
-                      result   (dir/direction graph request)]
-                  (is (s/valid? ::dataspecs/directions result)
-                      (str (expound/expound-str ::dataspecs/directions result))))))
+    (let [graph   @(router/pedestrian-graph {:SIZE i})
+          request  (gen/generate (s/gen ::dataspecs/params))
+          result   (dir/direction graph request)]
+      (is (s/valid? ::dataspecs/directions result)
+          (str (expound/expound-str ::dataspecs/directions result))))))
 
 ; -----------------------------------------------------------------
 ; generative tests for the direction endpoint
@@ -189,14 +189,14 @@
 (defspec saarland-directions
   30; tries -> expensive test
   (prop/for-all [i (gen/large-integer* {:min 0 :max 100})]
-                (let [graph    (deref (deref network)) ;; delay atom
-                      nodes    (alg/nodes graph)
-                      src      (dir/->coordinates (:node/location (nth nodes i)))
-                      dst      (dir/->coordinates (:node/location (nth nodes (* 2 i))))
-                      depart   (gen/generate (s/gen ::dataspecs/departure))
-                      args     {:coordinates [src dst] :departure depart :steps true}
-                      result   (dir/direction graph args)]
-                  (is (s/valid? ::dataspecs/directions result)
-                      (str (expound/expound-str ::dataspecs/directions result))))))
+    (let [graph    (deref (deref network)) ;; delay atom
+          nodes    (alg/nodes graph)
+          src      (dir/->coordinates (:node/location (nth nodes i)))
+          dst      (dir/->coordinates (:node/location (nth nodes (* 2 i))))
+          depart   (gen/generate (s/gen ::dataspecs/departure))
+          args     {:coordinates [src dst] :departure depart :steps true}
+          result   (dir/direction graph args)]
+      (is (s/valid? ::dataspecs/directions result)
+          (str (expound/expound-str ::dataspecs/directions result))))))
 
 ;(clojure.test/run-tests)

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -175,11 +175,11 @@
 (defspec generative-directions
   100; tries
   (prop/for-all [i (gen/large-integer* {:min 10 :max 20})]
-    (let [graph   @(router/pedestrian-graph {:SIZE i})
-          request  (gen/generate (s/gen ::dataspecs/params))
-          result   (dir/direction graph request)]
-      (is (s/valid? ::dataspecs/route result)
-          (str (expound/expound-str ::dataspecs/route result))))))
+                (let [graph   @(router/pedestrian-graph {:SIZE i})
+                      request  (gen/generate (s/gen ::dataspecs/params))
+                      result   (dir/direction graph request)]
+                  (is (s/valid? ::dataspecs/directions result)
+                      (str (expound/expound-str ::dataspecs/directions result))))))
 
 ; -----------------------------------------------------------------
 ; generative tests for the direction endpoint
@@ -189,14 +189,14 @@
 (defspec saarland-directions
   30; tries -> expensive test
   (prop/for-all [i (gen/large-integer* {:min 0 :max 100})]
-    (let [graph    (deref (deref network)) ;; delay atom
-          nodes    (alg/nodes graph)
-          src      (dir/->coordinates (:node/location (nth nodes i)))
-          dst      (dir/->coordinates (:node/location (nth nodes (* 2 i))))
-          depart   (gen/generate (s/gen ::dataspecs/departure))
-          args     {:coordinates [src dst] :departure depart :steps true}
-          result   (dir/direction graph args)]
-      (is (s/valid? ::dataspecs/route result)
-          (str (expound/expound-str ::dataspecs/route result))))))
+                (let [graph    (deref (deref network)) ;; delay atom
+                      nodes    (alg/nodes graph)
+                      src      (dir/->coordinates (:node/location (nth nodes i)))
+                      dst      (dir/->coordinates (:node/location (nth nodes (* 2 i))))
+                      depart   (gen/generate (s/gen ::dataspecs/departure))
+                      args     {:coordinates [src dst] :departure depart :steps true}
+                      result   (dir/direction graph args)]
+                  (is (s/valid? ::dataspecs/directions result)
+                      (str (expound/expound-str ::dataspecs/directions result))))))
 
 ;(clojure.test/run-tests)

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -178,8 +178,8 @@
     (let [graph   @(router/pedestrian-graph {:SIZE i})
           request  (gen/generate (s/gen ::dataspecs/params))
           result   (dir/direction graph request)]
-      (is (s/valid? ::dataspecs/response result)
-          (str (expound/expound-str ::dataspecs/response result))))))
+      (is (s/valid? ::dataspecs/route result)
+          (str (expound/expound-str ::dataspecs/route result))))))
 
 ; -----------------------------------------------------------------
 ; generative tests for the direction endpoint
@@ -196,7 +196,7 @@
           depart   (gen/generate (s/gen ::dataspecs/departure))
           args     {:coordinates [src dst] :departure depart :steps true}
           result   (dir/direction graph args)]
-      (is (s/valid? ::dataspecs/response result)
-          (str (expound/expound-str ::dataspecs/response result))))))
+      (is (s/valid? ::dataspecs/route result)
+          (str (expound/expound-str ::dataspecs/route result))))))
 
 ;(clojure.test/run-tests)

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -196,7 +196,7 @@
             depart   (gen/generate (s/gen ::dataspecs/departure))
             args     {:coordinates [src dst] :departure depart :steps true}
             response (future (dir/direction graph args))
-            result   (deref response 800 ::timeout)]
+            result   (deref response 1500 ::timeout)]
         (when (= result ::timeout)
           (println "timeout"))
         (is (or (= result ::timeout)

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -187,7 +187,7 @@
 (def network (delay (time (router/network {:area/edn "resources/frankfurt_am_main.edn.gzip"}))))
 
 (defspec routing-directions
-  20; tries -> expensive test
+  15; tries -> expensive test
   (let [graph    (deref (deref network)) ;; delay atom
         nodes    (alg/nodes graph)
         gc       (count nodes)]
@@ -197,7 +197,7 @@
             depart   (gen/generate (s/gen ::dataspecs/departure))
             args     {:coordinates [src dst] :departure depart :steps true}
             response (future (dir/direction graph args))
-            result   (deref response 3500 ::timeout)]
+            result   (deref response 5000 ::timeout)]
         (when (= result ::timeout)
           (println "timeout"))
         (is (or (= result ::timeout)

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -184,7 +184,7 @@
 ; -----------------------------------------------------------------
 ; generative tests for the direction endpoint
 
-(def network (delay (time (router/network {:area/edn "resources/saarland.edn.bz2"}))))
+(def network (delay (time (router/network {:area/edn "resources/frankfurt_am_main.edn.gzip"}))))
 
 (defspec saarland-directions
   30; tries -> expensive test


### PR DESCRIPTION
- make preprocessing step mandatory since it makes things simpler on the rest of the code
- compress edn files through gzip not bz2  -- not so small but equaly fast and supported natively by JVM
- switched to frankfurt am main files -- no point in keeping saarland files if I cannot double check the validity of gtfs routing
- environment variables preprocessing made explicit instead of through spec coercion

- LocalTime replaced by ZonedDateTime to avoid exposing java classes as response and instead use `seconds` as transfer unit
- fixes #211 
- fixes #203