### PR TITLE
refactored Dijkstra algorithm

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.13.1"
+(defproject hiposfer/kamal "0.14.0"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"

--- a/project.clj
+++ b/project.clj
@@ -30,8 +30,8 @@
              :release {:aot [hiposfer.kamal.core] ;; compile the entry point and all of its dependencies}
                        :main hiposfer.kamal.core
                        :uberjar-name "kamal.jar"
-                       :jar-exclusions [#".*\.gzip" #".*\.zip"]
-                       :uberjar-exclusions [#".*\.gzip" #".*\.zip"]
+                       :jar-exclusions [#".*\.gz" #".*\.zip"]
+                       :uberjar-exclusions [#".*\.gz" #".*\.zip"]
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}}
   :test-selectors {:default (complement :benchmark)
                    :benchmark :benchmark}

--- a/src/hiposfer/kamal/core.clj
+++ b/src/hiposfer/kamal/core.clj
@@ -58,8 +58,8 @@
                     [k (edn/read-string v)]))
         sconfig (into {} server)
         areas   (into {} (filter #(re-matches area-regex (name (key %)))) env)]
-    (assert (s/valid? ::areas areas) (s/explain ::areas areas))
-    (assert (s/valid? ::env sconfig) (s/explain ::env sconfig))
+    (assert (s/valid? ::areas areas) (s/explain-str ::areas areas))
+    (assert (s/valid? ::env sconfig) (s/explain-str ::env sconfig))
     (merge sconfig {:networks (prepare-areas areas)})))
 
 (defn system

--- a/src/hiposfer/kamal/network/algorithms/core.clj
+++ b/src/hiposfer/kamal/network/algorithms/core.clj
@@ -1,34 +1,22 @@
 (ns hiposfer.kamal.network.algorithms.core
   (:require [hiposfer.kamal.network.algorithms.dijkstra :as djk]
-            [hiposfer.kamal.libs.fastq :as fastq]
             [datascript.core :as data]))
-
-(def defaults {:value-by (constantly 1)
-               :comparator compare})
 
 (defn dijkstra
   "returns a sequence of traversal-paths taken to reach each node
 
   Parameters:
-   - graph: an collection of nodes over which the traversal will happen.
-            Expected to be a Datascript db but need not be
-   - start-from is a set of
+   - router: an implementation of the Router protocol to direct the 'movement'
+      of the graph traversal
+   - start-from: is a set of either
       - entities to start searching from
       - [entity init] pair where init is value to start settling nodes
-   - opts: is a map of options with the following keys
-     :successors -> a function of graph, id -> [ id ]. Used to get the id of
-                    the next nodes value-by successors
-     :value-by -> a function of graph, node , trail -> cost
-     :comparator -> a comparator function as defined by Clojure and Java.
-                    defaults to clojure/compare
-
-   NOTE: a Trail is a sequence of [id Valuable]. In other words it is the trail
-         taken to get from the first settled node to the current one"
-  [graph start-from opts]
-  (let [opts (merge defaults opts)]
-    (djk/->Dijkstra graph start-from (:value-by opts)
-                                     (:successors opts)
-                                     (:comparator opts))))
+   - comparator: a standard java.util.comparator implementation to compare the
+      values returned by the router. Defaults to Clojure's compare function"
+  ([router start-from]
+   (dijkstra router start-from compare))
+  ([router start-from comparator]
+   (djk/->Dijkstra router start-from comparator)))
 
 (defn shortest-path
   "returns the path taken to reach dst using the provided graph traversal"
@@ -49,14 +37,13 @@
    component of a undirected graph
 
    NOTE: only relevant for pedestrian routing"
-  [network settled]
+  [network router settled]
   (if (= (count (nodes network)) (count settled)) (list)
     (let [start     (some #(and (not (settled %)) %)
                            (nodes network))
           connected (sequence (comp (map first) (map key))
-                              (dijkstra network #{start}
-                                {:successors fastq/node-successors}))]
-     (cons connected (lazy-seq (components network (into settled connected)))))))
+                              (dijkstra router #{start}))]
+     (cons connected (lazy-seq (components network router (into settled connected)))))))
 
 ;; note for specs: the looner of the looner should be empty
 (defn looners
@@ -64,7 +51,7 @@
   because they are not part of the strongest connected component
 
   NOTE: only relevant for pedestrian routing"
-  [network]
-  (let [subsets   (components network #{})
+  [network router]
+  (let [subsets   (components network router #{})
         connected (into #{} (apply max-key count subsets))]
     (remove #(contains? connected %) (nodes network))))

--- a/src/hiposfer/kamal/network/algorithms/protocols.clj
+++ b/src/hiposfer/kamal/network/algorithms/protocols.clj
@@ -9,3 +9,10 @@
 (defprotocol GeoCoordinate
   (lat [this] "latitude in decimal numbers")
   (lon [this] "longitude in decimal numbers"))
+
+(defprotocol Router
+  "An instance used to direct the movement of Dijkstra's traversal algorithm"
+  (weight [this node trail]
+    "returns a Valuable implementation to order node in the Dijkstra heap")
+  (successors [this node]
+    "returns a sequence of node that can be reached from node"))

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -210,11 +210,11 @@
                                      (. departure (toLocalTime)))
         src        (first (fastq/nearest-node network (first coordinates)))
         dst        (first (fastq/nearest-node network (last coordinates)))
+        router     (transit/->StopTimesRouter network stop-times)
        ; both start and dst should be found since we checked that before
-        traversal  (alg/dijkstra network #{[src (. start (getSeconds))]}
-                                 {:value-by   #(transit/timetable-duration network stop-times %1 %2)
-                                  :successors transit/successors
-                                  :comparator transit/by-cost})
+        traversal  (alg/dijkstra router
+                                 #{[src (. start (getSeconds))]}
+                                 transit/by-cost)
         rtrail     (alg/shortest-path dst traversal)]
     (when (some? rtrail)
       (merge

--- a/src/hiposfer/kamal/services/routing/transit.clj
+++ b/src/hiposfer/kamal/services/routing/transit.clj
@@ -34,16 +34,6 @@
   [network next-entity trail] ;; 1 is a simple value used for test whenever no other value would be suitable
   (walk-time (key (first trail)) next-entity))
 
-;; a TripStep represents the transition between two stops in a GTFS feed
-;; Both the source and destination :stop_time are kept to avoid future lookups
-(defrecord TripStep [start end ^Long value]
-  np/Valuable
-  (cost [_] value)
-  (sum [this that] (assoc this :value (+ value (np/cost that)))))
-;; compare based on value not on trip. Useful for Fibonacci Heap order
-;Comparable
-;(compareTo [_ that] (compare value (np/cost that))))
-
 (defn by-cost
   "comparator to avoid CastClassException due to Java's Long limited comparison"
   [a b]
@@ -55,7 +45,6 @@
 (defn node? [e] (:node/id e))
 (defn way? [e] (:way/id e))
 (defn stop? [e] (:stop/id e))
-(defn trip-step? [o] (instance? TripStep o))
 
 (defn name
   "returns a name that represents this entity in the network.
@@ -109,44 +98,49 @@
         (common-road network (key (first piece)) (key (second piece)))
         (common-road network (key (first piece)))))))
 
-(defn successors
-  "takes a network and an entity id and returns the successors of that entity"
-  [network entity]
-  (let [id           (:db/id entity)
-        predecessors (eduction (fastq/index-lookup network id)
-                               (data/index-range network :node/successors id nil))]
-    (if (node? entity)
-      (concat predecessors (:node/successors entity))
-      (concat predecessors (:stop/successors entity)))))
+;; a TripStep represents the transition between two stops in a GTFS feed
+;; Both the source and destination :stop_time are kept to avoid future lookups
+(defrecord TripStep [start end ^Long value]
+  np/Valuable
+  (cost [_] value)
+  (sum [this that] (assoc this :value (+ value (np/cost that)))))
 
-(defn timetable-duration
-  "provides routing calculations using both GTFS feed and OSM nodes. Returns
-  a Long for walking parts and a TripStep for GTFS related ones."
-  [network stop-times dst trail]
-  (let [[src value] (first trail)
-        now         (np/cost value)]
-    (cond
-      ;; The user just walking so we route based on walking duration
-      (node? src)
-      (long (walk-time src dst))
-      ;; the user is trying to leave a vehicle. Apply penalty but route
-      ;; normally
-      (and (stop? src) (node? dst))
-      (+ penalty (long (walk-time src dst)))
-      ;; the user is trying to get into a vehicle. We need to find the next
-      ;; coming trip
-      (and (stop? src) (stop? dst) (not (trip-step? value)))
-      (let [[st1 st2] (fastq/find-trip network stop-times src dst now)]
-        (when (some? st2) ;; nil if no trip was found
-          ;(println {:src (:stop/name src)
-          ;          :dst (:stop/name dst)
-          ;          :route (:route/short_name (:trip/route (:stop_time/trip st1)))
-          ;          :duration (- (:stop_time/arrival_time st2) now)})
-          (->TripStep st1 st2 (- (:stop_time/arrival_time st2) now))))
-      ;; the user is already in a trip. Just find the trip going to dst
-      :else
-      (let [?trip (:stop_time/trip (:start value))
-            st    (fastq/continue-trip network dst ?trip)]
-        (when (some? st)
-          (->TripStep (:end value) st
-                      (- (:stop_time/arrival_time st) now)))))))
+(defn trip-step? [o] (instance? TripStep o))
+;; compare based on value not on trip. Useful for Fibonacci Heap order
+;Comparable
+;(compareTo [_ that] (compare value (np/cost that))))
+
+
+(defrecord StopTimesRouter [network day-stops]
+  np/Router
+  (weight [this dst trail]
+    (let [[src value] (first trail)
+          now         (np/cost value)]
+      (cond
+        ;; The user just walking so we route based on walking duration
+        (node? src)
+        (long (walk-time src dst))
+        ;; the user is trying to leave a vehicle. Apply penalty but route
+        ;; normally
+        (and (stop? src) (node? dst))
+        (+ penalty (long (walk-time src dst)))
+        ;; the user is trying to get into a vehicle. We need to find the next
+        ;; coming trip
+        (and (stop? src) (stop? dst) (not (trip-step? value)))
+        (let [[st1 st2] (fastq/find-trip network day-stops src dst now)]
+          (when (some? st2) ;; nil if no trip was found
+            (->TripStep st1 st2 (- (:stop_time/arrival_time st2) now))))
+        ;; the user is already in a trip. Just find the trip going to dst
+        :else
+        (let [?trip (:stop_time/trip (:start value))
+              st    (fastq/continue-trip network dst ?trip)]
+          (when (some? st)
+            (->TripStep (:end value) st
+                        (- (:stop_time/arrival_time st) now)))))))
+  (successors [this entity]
+    (let [id           (:db/id entity)
+          predecessors (eduction (fastq/index-lookup network id)
+                                 (data/index-range network :node/successors id nil))]
+      (if (node? entity)
+        (concat predecessors (:node/successors entity))
+        (concat predecessors (:stop/successors entity))))))

--- a/test/hiposfer/kamal/network/benchmark.clj
+++ b/test/hiposfer/kamal/network/benchmark.clj
@@ -5,15 +5,12 @@
             [hiposfer.kamal.network.generators :as ng]
             [hiposfer.kamal.network.algorithms.core :as alg]
             [hiposfer.kamal.preprocessor :as preprocessor]
-            [hiposfer.kamal.services.routing.transit :as transit]
             [hiposfer.kamal.libs.geometry :as geometry]
             [hiposfer.kamal.services.routing.core :as router]
             [hiposfer.kamal.libs.fastq :as fastq]
+            [hiposfer.kamal.network.tests :as kt]
             [datascript.core :as data]
             [taoensso.timbre :as timbre]))
-
-(defn opts [network] {:value-by #(transit/duration network %1 %2)
-                      :successors fastq/node-successors})
 
 ;; This is just to show the difference between a randomly generated network
 ;; and a real-world network. The randomly generated network does not have a structure
@@ -24,11 +21,12 @@
         network (data/create-conn router/schema)
         _       (data/transact! network dt)
         src     (rand-nth (alg/nodes @network))
-        dst     (rand-nth (alg/nodes @network))]
+        dst     (rand-nth (alg/nodes @network))
+        router  (kt/->PedestrianRouter @network)]
     (timbre/info "\n\nDIJKSTRA forward with:" (count (alg/nodes @network)) "nodes")
     (timbre/info "**random graph")
     (c/quick-bench
-      (let [coll (alg/dijkstra @network #{src} (opts @network))]
+      (let [coll (alg/dijkstra router #{src})]
         (alg/shortest-path dst coll))
       :os :runtime :verbose)))
 
@@ -39,8 +37,10 @@
 (test/deftest ^:benchmark dijkstra-saarland-graph
   (let [src  (first (alg/nodes @network))
         dst  (last (alg/nodes @network))
-        r1   (alg/looners @network)
-        coll (alg/dijkstra @network #{src} (opts @network))]
+        router (kt/->PedestrianRouter @network)
+        r1   (alg/looners @network router)
+        router (kt/->PedestrianRouter @network)
+        coll (alg/dijkstra router #{src})]
     (timbre/info "\n\nDIJKSTRA forward with:" (count (alg/nodes @network)) "nodes")
     (timbre/info "saarland graph:")
     (c/quick-bench (alg/shortest-path dst coll)
@@ -49,7 +49,7 @@
     (timbre/info "using only strongly connected components of the original graph")
     (data/transact! @network (map #(vector :db.fn/retractEntity (:db/id %)) r1))
     (timbre/info "with:" (count (alg/nodes @network)) "nodes")
-    (let [coll (alg/dijkstra @network #{src} (opts @network))]
+    (let [coll (alg/dijkstra router #{src})]
       (c/quick-bench (alg/shortest-path dst coll)
         :os :runtime :verbose))))
 


### PR DESCRIPTION
- fixes #194
- related to #165 - this is not a spec but the protocol describes what each part is suppose to do
- Router protocol created to explicitly bind the execution requirements
- cosmetic changes. use `doseq` and `for` loop inside Dijkstra algorithm for readability

@mehdisadeghi this is mostly in preparation to your changes to o2g for frequency feed in gtfs. Once we introduce that in kamal, we would need to dynamically decide if we route based on stop-times or on frequencies since some gtfs feeds might have it, while other not.

With Router objects, this becomes much more easy to handle