### PR TITLE
Ways contraction

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.14.0"
+(defproject hiposfer/kamal "0.15.0"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"

--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -154,11 +154,12 @@
                     :let [entries (eduction (index-lookup network (:e trip))
                                             (data/index-range network :stop_time/trip (:e trip) nil))
                           stop_times (sort-by :stop_time/stop_sequence entries)]
-                    pair (map vector stop_times (rest stop_times))]
-                pair)]
-    (for [[from to] (distinct pairs)]
-      {:stop/id (:stop/id (:stop_time/stop from))
-       :stop/successors #{[:stop/id (:stop/id (:stop_time/stop to))]}})))
+                    [from to] (map vector stop_times (rest stop_times))]
+                [(:stop/id (:stop_time/stop from))
+                 (:stop/id (:stop_time/stop to))])]
+    (for [[from-id to-id] (distinct pairs)]
+      {:stop/id from-id
+       :stop/successors #{[:stop/id to-id]}})))
 
 ;(time (last (data/with @(first @(:networks (:router hiposfer.kamal.dev/system)))
 ;                       (cache-stop-successors @(first @(:networks (:router hiposfer.kamal.dev/system)))))))

--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -189,6 +189,8 @@
          :node/successors #{[:stop/id (:stop/id stop)]}}))))
 
 ;; this reduced my test query from 30 seconds to 8 seconds
+;; TODO: this process is still very slow. It takes around 45 seconds
+;; on the frankfurt area
 (defn cache-stop-successors
   "computes the next-stops for each stop and returns a transaction
   that will cache those results inside the :stop entities"

--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -132,15 +132,6 @@
                     (map :e))
               (data/datoms network :avet :stop_time/trip))))
 
-(defn- references
-  "returns all entities that reference entity through attribute k"
-  ([network k entity]
-   (references network k entity (map identity)))
-  ([network k entity xform]
-   (eduction (comp (index-lookup network (:db/id entity))
-                   xform)
-             (data/index-range network k (:db/id entity) nil))))
-
 ;; This might not be the best approach but it gets the job done for the time being
 (defn link-stops
   "takes a network, looks up the nearest node for each stop and returns

--- a/src/hiposfer/kamal/parsers/osm.clj
+++ b/src/hiposfer/kamal/parsers/osm.clj
@@ -55,7 +55,7 @@
   "returns the ways sequence including only the first/last and intersection
    nodes i.e. the connected nodes in a graph structure.
 
-  Uses the ::nodes of each way and counts which nodes appear more than once"
+  Uses the :way/nodes of each way and counts which nodes appear more than once"
   [ways]
   (let [point-count (frequencies (mapcat :way/nodes ways))]
     (for [way ways]
@@ -80,6 +80,37 @@
         (when-let [wn (some :way/name group)]
           {:way/name wn})))))
 
+(defn- join-ways
+  "merges ways that are linked to each other by their head or their tail.
+
+  This is an optimization HACK.
+
+  We artificially merge ways because OSM might decide to break a road into
+  reusable pieces (ways) which makes the graph representation very redundant.
+  This way we reduce both the amount of way entries in Datascript and the
+  amount of nodes"
+  ([group] (join-ways (rest group) (first group) nil))
+  ([ways current result]
+   (let [fncurrent (first (:way/nodes current))
+         lncurrent (last (:way/nodes current))
+         [point match] (some (fn [way]
+                               (cond
+                                 (= fncurrent (last  (:way/nodes way))) [:start way]
+                                 (= lncurrent (first (:way/nodes way))) [:end way]))
+                             ways)]
+     (cond
+       (empty? ways)
+       (conj result current)
+
+       (some? point)
+       (recur (remove #(= % match) ways)
+              (if (= :start point)
+                (update match :way/nodes concat (rest (:way/nodes current)))
+                (update current :way/nodes concat (rest (:way/nodes match))))
+              result)
+
+       :else (recur (rest ways) (first ways) (conj result current))))))
+
 (defn- entries
   "returns a [id node], {id way} or nil otherwise"
   [xml-entry]
@@ -96,21 +127,26 @@
   (let [nodes&ways    (into [] (comp (map entries) (remove nil?))
                                (:content (xml/parse raw-data)))
         ;; separate ways from nodes
-        ways          (simplify (filter :way/id nodes&ways))
+        way-groups    (group-by :way/name (filter :way/id nodes&ways))
+        ;ways          (simplify (filter :way/id nodes&ways))
+        ways          (simplify (mapcat (fn [[way-name group]]
+                                          (if (empty? way-name) group
+                                            (join-ways group)))
+                                        way-groups))
         roads         (roads ways)
         ;; post-processing nodes
         ids           (into #{} (mapcat :way/nodes) ways)
-        nodes         (eduction (filter :node/id)
-                                (filter #(contains? ids (:node/id %)))
-                                nodes&ways)
-        neighbours    (mapcat (fn [way]
-                                (map (fn [from to]
-                                       {:node/id         from
-                                        :node/successors #{[:node/id to]}})
-                                     (:way/nodes way)
-                                     (rest (:way/nodes way))))
-                              ways)]
-    (concat nodes neighbours roads
+        nodes         (for [entry nodes&ways
+                            :when (contains? ids (:node/id entry))]
+                        entry)
+        neighbours    (for [way ways
+                            [from to] (map vector (:way/nodes way)
+                                                  (rest (:way/nodes way)))]
+                        {:node/id         from
+                         :node/successors #{[:node/id to]}})]
+    (concat nodes
+            (map #(dissoc % :way/nodes) roads)
+            neighbours
             (for [way roads
                   n (:way/nodes way)]
               {:node/id n

--- a/src/hiposfer/kamal/parsers/osm.clj
+++ b/src/hiposfer/kamal/parsers/osm.clj
@@ -14,7 +14,7 @@
 ;; name_1=* Street Name (Alternate). Also reg_name / loc_name / old_name
 ;; ref=*    Route network and number, but information from parent Route Relations has priority,
 ;;          see below. Also int_ref=* / nat_ref=* / reg_ref=* / loc_ref=* / old_ref=*
-(def way-attrs #{"name" "id" "nodes"}) ;:name_1 :ref}})
+(def way-attrs #{"name"})
 
 ;; <node id="298884269" lat="54.0901746" lon="12.2482632" user="SvenHRO"
 ;;      uid="46882" visible="true" version="1" changeset="676636"
@@ -38,33 +38,18 @@
 (defn- ways-entry
   "parse a OSM xml-way into a [way-id {attrs}] representing the same way"
   [element] ;; returns '(arc1 arc2 ...)
-  (let [attrs (into {} (comp (filter #(= :tag (:tag %)))
-                             (map    (fn [el] [(:k (:attrs el))
-                                               (:v (:attrs el))])))
-                       (:content element))
-        nodes (into [] (comp (filter #(= :nd (:tag %)))
-                             (map (comp :ref :attrs))
-                             (map #(Long/parseLong %)))
-                       (:content element))]
-    (merge attrs
-      {"id" (Long/parseLong (:id (:attrs element)))
-       "nodes" nodes})))
-
-;; we ignore the oneway tag since we only care about pedestrian routing. See
-;; https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Telenav
-(defn- postprocess
-  "return a {id way} pair with all unnecessary attributes removed with the
-   exception of ::nodes. Reverse nodes if necessary"
-  [way]
-  (into {} (map (fn [[k v]] [(keyword "way" k) v])
-                (select-keys way way-attrs))))
-
-(defn- strip-points
-  "returns way with only the first/last and intersection nodes"
-  [intersections way]
-  (let [intersections (conj intersections (first (:way/nodes way))
-                                          (last  (:way/nodes way)))]
-    (assoc way :way/nodes (filter intersections (:way/nodes way)))))
+  (let [attrs (eduction (filter #(= :tag (:tag %)))
+                        (filter #(contains? way-attrs (:k (:attrs %))))
+                        (map    #(vector (keyword "way" (:k (:attrs %)))
+                                         (:v (:attrs %))))
+                        (:content element))
+        nodes (eduction (filter #(= :nd (:tag %)))
+                        (map (comp :ref :attrs))
+                        (map #(Long/parseLong %))
+                        (:content element))]
+    (into {:way/id (Long/parseLong (:id (:attrs element)))
+           :way/nodes nodes}
+          attrs)))
 
 (defn simplify
   "returns the ways sequence including only the first/last and intersection
@@ -72,48 +57,68 @@
 
   Uses the ::nodes of each way and counts which nodes appear more than once"
   [ways]
-  (let [point-count   (frequencies (mapcat :way/nodes ways))
-        intersections (into #{} (comp (filter #(>= (second %) 2))
-                                      (map first))
-                                point-count)]
-    (map #(strip-points intersections %) ways)))
+  (let [point-count (frequencies (mapcat :way/nodes ways))]
+    (for [way ways]
+      (assoc way :way/nodes
+        (filter #(or (= % (first (:way/nodes way)))
+                     (>= (point-count %) 2)
+                     (= % (last (:way/nodes way))))
+                 (:way/nodes way))))))
+
+(defn- join-ways
+  "merges ways that are linked to each other by their head or their tail.
+  This is an optimization HACK. We artificially merge ways because OSM
+  might decide to break a road into reusable pieces (ways) which makes
+  the graph representation very redundant. This way we reduce both the
+  amount of way entries in Datascript and the amount of nodes"
+  ([group] (join-ways (rest group) (first group) nil))
+  ([ways current result]
+   (let [fncurrent (first (:way/nodes current))
+         lncurrent (last (:way/nodes current))
+         [point match] (some (fn [way]
+                               (cond
+                                 (= fncurrent (last  (:way/nodes way))) [:start way]
+                                 (= lncurrent (first (:way/nodes way))) [:end way]))
+                             ways)]
+     (cond
+       (empty? ways)
+       (conj result current)
+
+       (some? point)
+       (recur (remove #(= % match) ways)
+              (if (= :start point)
+                (update match :way/nodes concat (rest (:way/nodes current)))
+                (update current :way/nodes concat (rest (:way/nodes match))))
+              result)
+
+       :else (recur (rest ways) (first ways) (conj result current))))))
 
 (defn- entries
   "returns a [id node], {id way} or nil otherwise"
   [xml-entry]
   (case (:tag xml-entry)
     :node (point-entry xml-entry)
-    :way  (postprocess (ways-entry xml-entry))
+    :way  (ways-entry xml-entry)
     nil))
 
-;; There are generally speaking two ways to process an OSM file for routing
-; - read all points and ways and transform them in memory
-; - read it once, extract the ways and then read it again and extract only the relevant nodes
-
-;; The first option is faster since reading from disk is always very slow
-;; The second option uses less memory but takes at least twice as long (assuming reading takes the most time)
-
-;; We use the first option since it provides faster server start time. We assume
-;; that preprocessing the files was already performed and that only the useful
-;; data is part of the OSM file. See README
-
-;; TODO: deduplicate strings in ways name
-(defn datomize!
-  "read an OSM file and transforms it into a network of {:graph :ways :points},
-   such that the graph represent only the connected nodes, the points represent
-   the shape of the connection and the ways are the metadata associated with
-   the connections"
-  [input-stream] ;; read all elements into memory
-  (let [nodes&ways    (with-open [file-rdr input-stream]
-                        (into [] (comp (map entries)
-                                       (remove nil?))
-                              (:content (xml/parse file-rdr))))
+;; We assume that preprocessing the files was already performed and that only
+;; the useful data is part of the OSM file. See README
+(defn datomize
+  "read an OSM file and transforms it into a sequence of datascript transactions"
+  [raw-data] ;; read all elements into memory
+  (let [nodes&ways    (into [] (comp (map entries) (remove nil?))
+                               (:content (xml/parse raw-data)))
         ;; separate ways from nodes
-        ways          (simplify (filter :way/id nodes&ways))
+        way-groups    (group-by :way/name (filter :way/id nodes&ways))
+        ways          (simplify (mapcat (fn [[way-name group]]
+                                          (if (empty? way-name) group
+                                            (join-ways group)))
+                                        way-groups))
+        ;ways          (simplify (filter :way/id nodes&ways))
         ;; post-processing nodes
         ids           (into #{} (mapcat :way/nodes) ways)
-        nodes         (sequence (comp (filter :node/id)
-                                      (filter #(contains? ids (:node/id %))))
+        nodes         (eduction (filter :node/id)
+                                (filter #(contains? ids (:node/id %)))
                                 nodes&ways)
         neighbours    (for [way ways]
                         (map (fn [from to]
@@ -122,11 +127,12 @@
                              (:way/nodes way)
                              (rest (:way/nodes way))))]
     (concat nodes
-            (sequence cat neighbours)
-            (for [way ways]
-              (assoc way :way/nodes
-                (for [n (:way/nodes way)]
-                  [:node/id n]))))))
+            (apply concat neighbours)
+            (for [way ways] (dissoc way :way/nodes))
+            (for [way ways
+                  n (:way/nodes way)]
+              {:node/id n
+               :node/ways [:way/id (:way/id way)]}))))
 
 
 ;; https://www.wikiwand.com/en/Preferred_walking_speed

--- a/src/hiposfer/kamal/services/routing/core.clj
+++ b/src/hiposfer/kamal/services/routing/core.clj
@@ -26,14 +26,12 @@
                ;; Open Street Map - entities
                :node/id         {:db.unique :db.unique/identity}
                :node/location   {:db/index true}
+               :node/ways       {:db.type        :db.type/ref
+                                 :db.cardinality :db.cardinality/many}
                :node/successors {:db.type        :db.type/ref
                                  :db.cardinality :db.cardinality/many
                                  :db/index       true}
-
-                 :way/id          {:db.unique :db.unique/identity}
-                 :way/nodes       {:db.type        :db.type/ref
-                                   :db.cardinality :db.cardinality/many
-                                   :db/index       true}}
+               :way/id          {:db.unique :db.unique/identity}}
               ;; General Transfer Feed Specification - entities
               ;; identities
               (into {}

--- a/test/hiposfer/kamal/network/benchmark.clj
+++ b/test/hiposfer/kamal/network/benchmark.clj
@@ -30,7 +30,7 @@
         (alg/shortest-path dst coll))
       :os :runtime :verbose)))
 
-(def network (delay (time (preprocessor/fetch-osm {:area/name "Frankfurt am Main"}))))
+(def network (delay (time (preprocessor/fetch-osm! {:area/name "Frankfurt am Main"}))))
 
 ;;(type @network) ;; force read
 


### PR DESCRIPTION
- related to #180 - join similar ways to avoid redundancy in the db
- refactored stop relations caching for speed and clarity
- cosmetic changes

This PR changes the way that OSM ways are handled in kamal. Before they were kept as close to OSM ways as possible. Now they are only kept to represent attributes of the followed path, like the name. The relation its then stored directly in the node

EDIT: this improves preprocessing a lot, in my machine it reduces the frankfurt preprocessing from close to 3 minutes to a bit more than a minute. Apparently there were some bugs in the caching system for stops connections which were slowing the routing so this also reduces the directions response time