### PR TITLE
Cache OSM files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ $ git clone https://github.com/hiposfer/kamal.git && cd kamal
 $ export FRANKFURT_AREA_NAME="Frankfurt am Main"
 $ export FRANKFURT_AREA_GTFS=resources/test/frankfurt.gtfs.zip
 
-## preprocess input data
-$ lein run -m hiposfer.kamal.preprocessor resources/test/
+## preprocess input data -> output to ./resources/test
+$ lein run -m hiposfer.kamal.preprocessor
 
 ## compile application - you can run it with lein as well
 $ lein with-profile release uberjar

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.16.0"
+(defproject hiposfer/kamal "0.16.1"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"

--- a/src/hiposfer/kamal/preprocessor.clj
+++ b/src/hiposfer/kamal/preprocessor.clj
@@ -30,7 +30,7 @@
 
 (defn- read-osm
   [area]
-  (println "reading OSM cache file from" (osm-filename area))
+  (println "OK - OSM cache file found at" (osm-filename area))
   (with-open [stream (io/input-stream (osm-filename area))]
     (osm/transaction! stream)))
 
@@ -59,8 +59,8 @@
   (with-open [z (-> (io/input-stream (:area/gtfs area))
                     (ZipInputStream.))]
     (as-> (data/empty-db routing/schema) $
-          (time (data/db-with $ (gtfs/transaction! z)))
           (time (data/db-with $ (fetch-osm! area)))
+          (time (data/db-with $ (gtfs/transaction! z)))
           (time (data/db-with $ (fastq/link-stops $)))
           (time (data/db-with $ (fastq/cache-stop-successors $)))
           (time (data/db-with $ [area]))))) ;; add the area as transaction


### PR DESCRIPTION
PROBLEM: overpass-api throtles the download of OSM data

SOLUTION: cache the output locally and reuse it next time