### PR TITLE
miscelaneous changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ script:
 - lein do clean, compile, check, eastwood
 # HACK: download the file before the test starts
 - wget -O ./resources/test/frankfurt-am-main.edn.gz ${FRANKFURT_AREA_EDN}
-- lein trampoline test
+- if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
+  lein trampoline test :benchmark
+  else
+  lein trampoline test
+  fi
+
 deploy:
 # deploy to clojars
 - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ script:
 - lein do clean, compile, check, eastwood
 # HACK: download the file before the test starts
 - wget -O ./resources/test/frankfurt-am-main.edn.gz ${FRANKFURT_AREA_EDN}
-- if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
-  lein trampoline test :benchmark
+- if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
+    lein trampoline test :benchmark;
   else
-  lein trampoline test
+    lein trampoline test;
   fi
 
 deploy:

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,6 @@
                  [ring-middleware-accept "2.0.3"] ;; http accept header
                  [hiposfer/geojson.specs "0.2.0"]
                  [hiposfer/gtfs.edn "0.1.1"]
-                 [com.taoensso/timbre "4.10.0"] ;; logging functions
                  [com.stuartsierra/component "0.3.2"] ;; system builder and resource management
                  [org.teneighty/java-heaps "1.0.0"] ;; for performance in dijkstra routing
                  [org.clojure/data.csv "0.1.4"] ;; for gtfs parsing

--- a/src/hiposfer/kamal/core.clj
+++ b/src/hiposfer/kamal/core.clj
@@ -12,7 +12,6 @@
   (:require [com.stuartsierra.component :as component]
             [hiposfer.kamal.services.webserver.core :as webserver]
             [hiposfer.kamal.services.routing.core :as routing]
-            [taoensso.timbre :as timbre]
             [clojure.walk :as walk]
             [clojure.spec.alpha :as s]
             [clojure.string :as str]
@@ -76,7 +75,7 @@
 
 (defn -main
   [& args]
-  (timbre/info "\n\nWelcome to the hiposfer/kamal App")
+  (println "\n\nWelcome to the hiposfer/kamal App")
   (let [env    (walk/keywordize-keys (into {} (System/getenv)))
         config (prepare-env env)]
     (component/start (system config))))

--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -13,8 +13,7 @@
             [expound.alpha :as expound]
             [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha]
-            [clojure.tools.namespace.repl :as repl]
-            [taoensso.timbre :as timbre]))
+            [clojure.tools.namespace.repl :as repl]))
 
 (def env
   "a fake environment variables setting for development"
@@ -34,13 +33,13 @@
 (defn start!
   "Starts the current development system."
   []
-  (timbre/debug "Starting System")
+  (println "Starting System")
   (alter-var-root #'system component/start))
 
 (defn stop!
   "Shuts down and destroys the current development system."
   []
-  (timbre/debug "Stopping System\n")
+  (println "Stopping System\n")
   (alter-var-root #'system (fn [s] (when s (component/stop s)))))
 
 (defn custom-printer

--- a/src/hiposfer/kamal/parsers/gtfs.clj
+++ b/src/hiposfer/kamal/parsers/gtfs.clj
@@ -19,7 +19,7 @@
             [hiposfer.kamal.network.core :as network]
             [clojure.java.io :as io]
             [clojure.data.csv :as csv]
-            [clojure.tools.reader.edn :as edn]
+            [clojure.edn :as edn]
             [datascript.impl.entity :as dimp])
   (:import (java.util.zip ZipInputStream ZipEntry)
            (java.time Duration LocalDate ZoneId)

--- a/src/hiposfer/kamal/preprocessor.clj
+++ b/src/hiposfer/kamal/preprocessor.clj
@@ -1,7 +1,6 @@
 (ns hiposfer.kamal.preprocessor
   (:gen-class)
   (:require [clojure.java.io :as io]
-            [taoensso.timbre :as timbre]
             [hiposfer.kamal.dev :as dev]
             [hiposfer.kamal.services.routing.core :as routing]
             [hiposfer.kamal.core :as core]
@@ -72,7 +71,7 @@
   ;; setup spec instrumentation and expound for better feedback
   (clojure.spec.test.alpha/instrument)
   (alter-var-root #'s/*explain-out* (constantly dev/custom-printer))
-  (timbre/info "preprocessing OSM and GTFS files")
+  (println "preprocessing OSM and GTFS files")
 
   (let [env    (walk/keywordize-keys (into {} (System/getenv)))
         areas  (into {} (filter #(re-matches core/area-regex (name (key %)))) env)]

--- a/src/hiposfer/kamal/services/webserver/core.clj
+++ b/src/hiposfer/kamal/services/webserver/core.clj
@@ -2,7 +2,6 @@
   (:require [com.stuartsierra.component :as component]
             [hiposfer.kamal.services.webserver.handlers :as handler]
             [ring.adapter.jetty :as jetty]
-            [taoensso.timbre :as timbre]
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
             [ring.middleware.nested-params :refer [wrap-nested-params]]
             [ring.middleware.params :refer [wrap-params]]
@@ -69,11 +68,11 @@
                         (wrap-params))
             server  (jetty/run-jetty handler {:join? (:JOIN_THREAD config)
                                               :port  (:PORT config)})]
-        (timbre/info "-- Starting App server")
+        (println "-- Starting App server")
         (assoc this :server server))))
   (stop [this]
     (if-let [server (:server this)]
-      (do (timbre/info "-- Stopping App server")
+      (do (println "-- Stopping App server")
           (.stop ^Server server)
           (.join ^Server server)
           (assoc this :server nil router nil)))


### PR DESCRIPTION
- benchmark refactored
- benchmark added to travis
- `timbre` removed - use println for the time being
- fixes #236 - use `send` instead of send-off to use a pool of threads