### PR TITLE
renamed nearest-node to nearest-nodes

### DIFF
--- a/resources/benchmark.txt
+++ b/resources/benchmark.txt
@@ -1,74 +1,72 @@
 
 Testing hiposfer.kamal.network.benchmark
-"Elapsed time: 22082.581716 msecs"
+"Elapsed time: 23708.986592 msecs"
 
 
-DIJKSTRA forward with: 126261 nodes
-saarland graph:
-x86_64 Mac OS X 10.13.3 8 cpu(s)
+Road network: nearest neighbour search with random src/dst
+B+ tree with: 1886816 nodes
+accuracy:  14.397657786540089 meters
+x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.4.0 -Dclojure.debug=false
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.16.1 -Dclojure.debug=false
+Evaluation count : 11580 in 6 samples of 1930 calls.
+      Execution time sample mean : 56.852442 µs
+             Execution time mean : 56.890906 µs
+Execution time sample std-deviation : 4.987741 µs
+    Execution time std-deviation : 5.047377 µs
+   Execution time lower quantile : 52.667665 µs ( 2.5%)
+   Execution time upper quantile : 65.434293 µs (97.5%)
+                   Overhead used : 9.785290 ns
+
+Found 1 outliers in 6 samples (16.6667 %)
+	low-severe	 1 (16.6667 %)
+ Variance from outliers : 15.7477 % Variance is moderately inflated by outliers
+
+
+Pedestrian routing with: 50900 nodes
+x86_64 Mac OS X 10.13.6 8 cpu(s)
+Java HotSpot(TM) 64-Bit Server VM 25.101-b13
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.16.1 -Dclojure.debug=false
 Evaluation count : 6 in 6 samples of 1 calls.
-      Execution time sample mean : 323.520807 ms
-             Execution time mean : 323.678169 ms
-Execution time sample std-deviation : 12.205431 ms
-    Execution time std-deviation : 12.262344 ms
-   Execution time lower quantile : 317.359162 ms ( 2.5%)
-   Execution time upper quantile : 344.430490 ms (97.5%)
-                   Overhead used : 1.777881 ns
+      Execution time sample mean : 475.860954 ms
+             Execution time mean : 475.737000 ms
+Execution time sample std-deviation : 5.111158 ms
+    Execution time std-deviation : 5.255535 ms
+   Execution time lower quantile : 467.205702 ms ( 2.5%)
+   Execution time upper quantile : 480.110394 ms (97.5%)
+                   Overhead used : 9.785290 ns
+
+
+Transit routing with: 50900 nodes
+x86_64 Mac OS X 10.13.6 8 cpu(s)
+Java HotSpot(TM) 64-Bit Server VM 25.101-b13
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.16.1 -Dclojure.debug=false
+Evaluation count : 6 in 6 samples of 1 calls.
+      Execution time sample mean : 893.860483 ms
+             Execution time mean : 893.831166 ms
+Execution time sample std-deviation : 1.174853 ms
+    Execution time std-deviation : 1.342164 ms
+   Execution time lower quantile : 891.913395 ms ( 2.5%)
+   Execution time upper quantile : 895.305971 ms (97.5%)
+                   Overhead used : 9.785290 ns
 
 Found 1 outliers in 6 samples (16.6667 %)
 	low-severe	 1 (16.6667 %)
  Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
---------
-using only strongly connected components of the original graph
-with: 124163 nodes
-x86_64 Mac OS X 10.13.3 8 cpu(s)
+
+
+DIJKSTRA forward with: 1018 nodes
+x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.4.0 -Dclojure.debug=false
-Evaluation count : 6 in 6 samples of 1 calls.
-      Execution time sample mean : 332.523516 ms
-             Execution time mean : 332.563869 ms
-Execution time sample std-deviation : 6.032307 ms
-    Execution time std-deviation : 6.403917 ms
-   Execution time lower quantile : 324.420256 ms ( 2.5%)
-   Execution time upper quantile : 338.288564 ms (97.5%)
-                   Overhead used : 1.777881 ns
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.16.1 -Dclojure.debug=false
+Evaluation count : 24 in 6 samples of 4 calls.
+      Execution time sample mean : 31.065121 ms
+             Execution time mean : 31.084560 ms
+Execution time sample std-deviation : 637.045963 µs
+    Execution time std-deviation : 645.379502 µs
+   Execution time lower quantile : 30.590367 ms ( 2.5%)
+   Execution time upper quantile : 32.071815 ms (97.5%)
+                   Overhead used : 9.785290 ns
 
-
-DIJKSTRA forward with: 1027 nodes
-**random graph
-x86_64 Mac OS X 10.13.3 8 cpu(s)
-Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.4.0 -Dclojure.debug=false
-Evaluation count : 30 in 6 samples of 5 calls.
-      Execution time sample mean : 21.542457 ms
-             Execution time mean : 21.540849 ms
-Execution time sample std-deviation : 351.648657 µs
-    Execution time std-deviation : 352.570812 µs
-   Execution time lower quantile : 21.361698 ms ( 2.5%)
-   Execution time upper quantile : 22.153571 ms (97.5%)
-                   Overhead used : 1.777881 ns
-
-Found 1 outliers in 6 samples (16.6667 %)
-	low-severe	 1 (16.6667 %)
- Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
-
-
-saarland graph: nearest neighbour search with random src/dst
-B+ tree with: 762902 nodes
-accuraccy:  40.21630396035512 meters
-x86_64 Mac OS X 10.13.3 8 cpu(s)
-Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -Xmx1g -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.4.0 -Dclojure.debug=false
-Evaluation count : 57948 in 6 samples of 9658 calls.
-      Execution time sample mean : 10.563998 µs
-             Execution time mean : 10.571648 µs
-Execution time sample std-deviation : 180.675629 ns
-    Execution time std-deviation : 189.814221 ns
-   Execution time lower quantile : 10.411067 µs ( 2.5%)
-   Execution time upper quantile : 10.812759 µs (97.5%)
-                   Overhead used : 1.777881 ns
-
-Ran 3 tests containing 0 assertions.
+Ran 4 tests containing 0 assertions.
 0 failures, 0 errors.

--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -35,7 +35,7 @@
                       (data/index-range network :node/successors id nil)))))
 
 
-(defn nearest-node
+(defn nearest-nodes
   "returns the nearest node/location to point"
   [network point]
   (eduction (map :e)
@@ -139,7 +139,7 @@
   [network]
   (for [stop (map #(data/entity network (:e %))
                    (data/datoms network :aevt :stop/id))]
-    (let [node (first (nearest-node network (:stop/location stop)))]
+    (let [node (first (nearest-nodes network (:stop/location stop)))]
       (if (not (some? node))
         (throw (ex-info "stop didnt match to any known node in the OSM data"
                         (into {} stop)))

--- a/src/hiposfer/kamal/network/algorithms/dijkstra.clj
+++ b/src/hiposfer/kamal/network/algorithms/dijkstra.clj
@@ -14,11 +14,11 @@
    sources id to the beginning of the queue and to the settled map."
   ^Heap [init-set ^Map settled comparator]
   (let [queue  ^Heap (new FibonacciHeap comparator)]
-    (run! (fn [value] (let [[e v] (if (vector? value) value [value 0])
-                            t (trace e nil)
-                            he (.insert queue v t)]
-                        (.put settled value he)))
-          init-set)
+    (doseq [entry init-set]
+      (let [[id cost]  (if (vector? entry) entry [entry 0])
+            pair       (trace id nil)
+            heap-entry (.insert queue cost pair)]
+        (.put settled entry heap-entry)))
     queue))
 
 (defn- path

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -208,8 +208,8 @@
         stop-times (fastq/day-stop-times network (. departure (toLocalDate)))
         start      (Duration/between (LocalTime/MIDNIGHT)
                                      (. departure (toLocalTime)))
-        src        (first (fastq/nearest-node network (first coordinates)))
-        dst        (first (fastq/nearest-node network (last coordinates)))
+        src        (first (fastq/nearest-nodes network (first coordinates)))
+        dst        (first (fastq/nearest-nodes network (last coordinates)))
         router     (transit/->StopTimesRouter network stop-times)
        ; both start and dst should be found since we checked that before
         traversal  (alg/dijkstra router

--- a/src/hiposfer/kamal/services/webserver/handlers.clj
+++ b/src/hiposfer/kamal/services/webserver/handlers.clj
@@ -27,7 +27,7 @@
 (defn- match-coordinates
   [network params]
   (for [coord (:coordinates params)
-        :let [node (:node/location (first (fastq/nearest-node network coord)))]
+        :let [node (:node/location (first (fastq/nearest-nodes network coord)))]
         :when (some? node)
         :let [dist (geometry/haversine coord node)]
         :when (< dist max-distance)]

--- a/test/hiposfer/kamal/network/benchmark.clj
+++ b/test/hiposfer/kamal/network/benchmark.clj
@@ -39,19 +39,19 @@
 (test/deftest ^:benchmark B-nearest-neighbour-search
   (let [network (deref (deref road/network))
         src     [8.645333, 50.087314]
-        point   (:node/location (first (fastq/nearest-node network src)))]
+        point   (:node/location (first (fastq/nearest-nodes network src)))]
     (newline) (newline)
     (println "Road network: nearest neighbour search with random src/dst")
     (println "B+ tree with:" (count (data/datoms network :eavt)) "nodes")
     (println "accuracy: " (geometry/haversine src point) "meters")
-    (c/quick-bench (:node/location (first (fastq/nearest-node network src)))
+    (c/quick-bench (:node/location (first (fastq/nearest-nodes network src)))
                    :os :runtime :verbose)))
 
 ;;(type @kt/network) ;; force read
 (test/deftest ^:benchmark C-pedestrian-road-network
   (let [network (deref (deref road/network))
-        src     (first (alg/nodes network))
-        dst     (last (alg/nodes network))
+        src     (first (fastq/nearest-nodes network [8.645333, 50.087314]))
+        dst     (first (fastq/nearest-nodes network [8.635897, 50.104172]))
         router  (kt/->PedestrianRouter network)
         coll    (alg/dijkstra router #{src})]
     (newline) (newline)
@@ -63,11 +63,9 @@
   (let [network    (deref (deref road/network))
         departure  (ZonedDateTime/parse "2018-05-07T10:15:30+02:00")
         stop-times (fastq/day-stop-times network (. departure (toLocalDate)))
-        coordinates [[8.645333, 50.087314]
-                     [8.635897, 50.104172]]
         start      (Duration/between (LocalTime/MIDNIGHT) (. departure (toLocalTime)))
-        src        (first (fastq/nearest-node network (first coordinates)))
-        dst        (first (fastq/nearest-node network (last coordinates)))
+        src        (first (fastq/nearest-nodes network [8.645333, 50.087314]))
+        dst        (first (fastq/nearest-nodes network [8.635897, 50.104172]))
         router     (transit/->StopTimesRouter network stop-times)
         coll       (alg/dijkstra router
                                  #{[src (. start (getSeconds))]}


### PR DESCRIPTION
use doseq instead of run! for readability
settled src and dst in benchmark to avoid relying on order of nodes