### PR TITLE
int graph

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,7 @@
                  [org.teneighty/java-heaps "1.0.0"] ;; for performance in dijkstra routing
                  [org.clojure/data.csv "0.1.4"] ;; for gtfs parsing
                  [datascript "0.16.6"]
+                 [org.clojure/data.int-map "0.2.4"] ;; fast int maps
                  [ch.hsr/geohash "1.3.0"]] ;; for nearest neighbour search
   ;; preprocessor - env vars are not passed along, so better run manually
   ;; ["trampoline" "run" "-m" "hiposfer.kamal.preprocessor"]}

--- a/resources/benchmark.txt
+++ b/resources/benchmark.txt
@@ -1,6 +1,6 @@
 
 Testing hiposfer.kamal.network.benchmark
-"Elapsed time: 15959.392755 msecs"
+"Elapsed time: 18510.606777 msecs"
 
 
 Road network: nearest neighbour search with random src/dst
@@ -8,61 +8,57 @@ B+ tree with: 1991267 nodes
 accuracy:  14.397657786540089 meters
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.17.0 -Dclojure.debug=false
-Evaluation count : 24912 in 6 samples of 4152 calls.
-      Execution time sample mean : 24.446363 µs
-             Execution time mean : 24.446363 µs
-Execution time sample std-deviation : 521.999631 ns
-    Execution time std-deviation : 521.999631 ns
-   Execution time lower quantile : 23.981849 µs ( 2.5%)
-   Execution time upper quantile : 25.295832 µs (97.5%)
-                   Overhead used : 1.900879 ns
-
-Found 1 outliers in 6 samples (16.6667 %)
-	low-severe	 1 (16.6667 %)
- Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.0 -Dclojure.debug=false
+Evaluation count : 25980 in 6 samples of 4330 calls.
+      Execution time sample mean : 22.501947 µs
+             Execution time mean : 22.495338 µs
+Execution time sample std-deviation : 441.677542 ns
+    Execution time std-deviation : 486.365532 ns
+   Execution time lower quantile : 22.013828 µs ( 2.5%)
+   Execution time upper quantile : 23.003327 µs (97.5%)
+                   Overhead used : 1.814603 ns
 
 
 Pedestrian routing with: 50915 nodes
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.17.0 -Dclojure.debug=false
-Evaluation count : 6 in 6 samples of 1 calls.
-      Execution time sample mean : 428.625414 ms
-             Execution time mean : 428.625414 ms
-Execution time sample std-deviation : 3.347324 ms
-    Execution time std-deviation : 3.547259 ms
-   Execution time lower quantile : 423.415334 ms ( 2.5%)
-   Execution time upper quantile : 431.847921 ms (97.5%)
-                   Overhead used : 1.900879 ns
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.0 -Dclojure.debug=false
+Evaluation count : 18 in 6 samples of 3 calls.
+      Execution time sample mean : 39.929551 ms
+             Execution time mean : 39.875935 ms
+Execution time sample std-deviation : 1.331996 ms
+    Execution time std-deviation : 1.407142 ms
+   Execution time lower quantile : 38.142296 ms ( 2.5%)
+   Execution time upper quantile : 41.308428 ms (97.5%)
+                   Overhead used : 1.814603 ns
 
 
 Transit routing with: 50915 nodes
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.17.0 -Dclojure.debug=false
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.0 -Dclojure.debug=false
 Evaluation count : 6 in 6 samples of 1 calls.
-      Execution time sample mean : 838.971549 ms
-             Execution time mean : 838.997812 ms
-Execution time sample std-deviation : 8.287298 ms
-    Execution time std-deviation : 8.605199 ms
-   Execution time lower quantile : 830.594816 ms ( 2.5%)
-   Execution time upper quantile : 851.119495 ms (97.5%)
-                   Overhead used : 1.900879 ns
+      Execution time sample mean : 384.816759 ms
+             Execution time mean : 384.919578 ms
+Execution time sample std-deviation : 6.690093 ms
+    Execution time std-deviation : 6.926220 ms
+   Execution time lower quantile : 377.719763 ms ( 2.5%)
+   Execution time upper quantile : 395.156839 ms (97.5%)
+                   Overhead used : 1.814603 ns
 
 
-DIJKSTRA forward with: 1023 nodes
+DIJKSTRA forward with: 1021 nodes
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.17.0 -Dclojure.debug=false
-Evaluation count : 117684 in 6 samples of 19614 calls.
-      Execution time sample mean : 5.288019 µs
-             Execution time mean : 5.287500 µs
-Execution time sample std-deviation : 45.116561 ns
-    Execution time std-deviation : 49.920018 ns
-   Execution time lower quantile : 5.216574 µs ( 2.5%)
-   Execution time upper quantile : 5.343364 µs (97.5%)
-                   Overhead used : 1.900879 ns
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.0 -Dclojure.debug=false
+Evaluation count : 228462 in 6 samples of 38077 calls.
+      Execution time sample mean : 2.680761 µs
+             Execution time mean : 2.678805 µs
+Execution time sample std-deviation : 39.775613 ns
+    Execution time std-deviation : 42.710638 ns
+   Execution time lower quantile : 2.619540 µs ( 2.5%)
+   Execution time upper quantile : 2.716540 µs (97.5%)
+                   Overhead used : 1.814603 ns
 
 Ran 4 tests containing 0 assertions.
 0 failures, 0 errors.

--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -19,16 +19,7 @@
 (defn node-edges
   "takes a network and an entity and returns the successors of that entity.
    Only valid for OSM nodes. Assumes bidirectional links i.e. nodes with
-   back-references to entity are also returned
-
-  replaces:
-  '[:find ?successors ?node
-    :in $ ?id
-    :where [?id :node/successors ?successors]
-           [?node :node/successors ?id]]
-
-  The previous query takes around 50 milliseconds to finish. This function
-  takes around 0.25 milliseconds"
+   back-references to entity are also returned"
   [entity]
   (let [network   (data/entity-db entity)
         target-id (:db/id entity)]

--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -55,9 +55,8 @@
 
    The previous query takes around 50 milliseconds to execute. This function
    takes around 0.22 milliseconds to execute. Depends on :stop_time/trip index"
-  [network dst trip]
-  (let [?dst-id  (:db/id dst)
-        ?trip-id (:db/id trip)]
+  [network ?dst-id trip]
+  (let [?trip-id (:db/id trip)]
     (tool/some #(= ?dst-id (:db/id (:stop_time/stop %)))
                 (references network :stop_time/trip ?trip-id))))
 
@@ -79,14 +78,14 @@
            [(hiposfer.kamal.libs.fastq/after? ?departure ?now)]]
 
   The previous query runs in 118 milliseconds. This function takes 4 milliseconds"
-  [network trips src dst now]
+  [network trips ?src-id ?dst-id now]
   (let [stop_times (eduction (map #(data/entity network (:e %)))
                              (filter #(contains? trips (:db/id (:stop_time/trip %))))
                              (filter #(> (:stop_time/departure_time %) now))
-                             (data/datoms network :avet :stop_time/stop (:db/id src)))]
+                             (data/datoms network :avet :stop_time/stop ?src-id))]
     (when (seq stop_times)
       (let [trip (apply min-key :stop_time/departure_time stop_times)]
-        [trip (continue-trip network dst (:stop_time/trip trip))]))))
+        [trip (continue-trip network ?dst-id (:stop_time/trip trip))]))))
 
 ;; src - [:stop/id 3392140086]
 ;; dst - [:stop/id 582939269]

--- a/src/hiposfer/kamal/network/algorithms/core.clj
+++ b/src/hiposfer/kamal/network/algorithms/core.clj
@@ -6,7 +6,7 @@
   "returns a sequence of traversal-paths taken to reach each node
 
   Parameters:
-   - router: an implementation of the Router protocol to direct the 'movement'
+   - router: an implementation Dijkstra protocol to direct the 'movement'
       of the graph traversal
    - start-from: is a set of either
       - entities to start searching from
@@ -34,26 +34,26 @@
                   (map #(data/entity network %)))
             (data/datoms network :aevt :node/id)))
 
-(defn- components
-  "returns a lazy sequence of sets of nodes' ids of each strongly connected
+#_(defn- components
+    "returns a lazy sequence of sets of nodes' ids of each strongly connected
    component of a undirected graph
 
    NOTE: only relevant for pedestrian routing"
-  [network router settled]
-  (if (= (count (nodes network)) (count settled)) (list)
-    (let [start     (some #(and (not (settled %)) %)
-                           (nodes network))
-          connected (sequence (comp (map first) (map key))
-                              (dijkstra router #{start}))]
-     (cons connected (lazy-seq (components network router (into settled connected)))))))
+    [network router settled]
+    (if (= (count (nodes network)) (count settled)) (list)
+      (let [start     (some #(and (not (settled %)) %)
+                             (nodes network))
+            connected (sequence (comp (map first) (map key))
+                                (dijkstra router #{start}))]
+       (cons connected (lazy-seq (components network router (into settled connected)))))))
 
 ;; note for specs: the looner of the looner should be empty
-(defn looners
-  "returns a sequence of ids that can be removed from the graph
+#_(defn looners
+    "returns a sequence of ids that can be removed from the graph
   because they are not part of the strongest connected component
 
   NOTE: only relevant for pedestrian routing"
-  [network router]
-  (let [subsets   (components network router #{})
-        connected (into #{} (apply max-key count subsets))]
-    (remove #(contains? connected %) (nodes network))))
+    [network router]
+    (let [subsets   (components network router #{})
+          connected (into #{} (apply max-key count subsets))]
+      (remove #(contains? connected %) (nodes network))))

--- a/src/hiposfer/kamal/network/algorithms/core.clj
+++ b/src/hiposfer/kamal/network/algorithms/core.clj
@@ -23,7 +23,8 @@
   "returns the path taken to reach dst using the provided graph traversal"
   [dst graph-traversal]
   (let [dst? (comp #{dst} key first)
-        rf   (fn [_ value] (when (dst? value) (reduced value)))]
+        rf   (fn [_ value]
+               (when (dst? value) (reduced value)))]
     (reduce rf nil graph-traversal)))
 
 (defn nodes

--- a/src/hiposfer/kamal/network/algorithms/dijkstra.clj
+++ b/src/hiposfer/kamal/network/algorithms/dijkstra.clj
@@ -41,7 +41,7 @@
         _      (. settled (put entity entry))
         _      (. unsettled (remove entity))
         trail  (path settled entity)]
-    (doseq [arc (np/successors entity)
+    (doseq [arc (np/successors (np/node router entity))
             :let [node (np/dst arc)]
             :when (not (. settled (containsKey node)))
             :let [weight (np/relax router arc trail)]

--- a/src/hiposfer/kamal/network/algorithms/protocols.clj
+++ b/src/hiposfer/kamal/network/algorithms/protocols.clj
@@ -26,5 +26,6 @@
   "An instance used to direct the movement of Dijkstra's traversal algorithm"
   #_(seed  [this] ;TODO
       "returns a sequence of [Node Valuable] that will be ")
+  (node [this key])
   (relax [this arc trail]
     "attempts to relax node following trail path. Returns a Valuable implementation"))

--- a/src/hiposfer/kamal/network/algorithms/protocols.clj
+++ b/src/hiposfer/kamal/network/algorithms/protocols.clj
@@ -18,13 +18,13 @@
   (mirror? [this] "returns true if this Link is a mirror of its original"))
 
 (defprotocol Node
-  (id           [this] "returns a unique identifier for this Context")
-  ;(predecessors [this] "returns the Links that point to this Context") TODO
+  #_(id           [this] "returns a unique identifier for this Context")
+  #_(predecessors [this] "returns the Links that point to this Context") ;TODO
   (successors   [this] "returns the Links that origin at this Context"))
 
 (defprotocol Router
   "An instance used to direct the movement of Dijkstra's traversal algorithm"
-  ;(seed  [this] TODO
-  ;  "returns a sequence of [Node Valuable] that will be "
+  #_(seed  [this] ;TODO
+      "returns a sequence of [Node Valuable] that will be ")
   (relax [this arc trail]
     "attempts to relax node following trail path. Returns a Valuable implementation"))

--- a/src/hiposfer/kamal/network/algorithms/protocols.clj
+++ b/src/hiposfer/kamal/network/algorithms/protocols.clj
@@ -22,10 +22,12 @@
   #_(predecessors [this] "returns the Links that point to this Context") ;TODO
   (successors   [this] "returns the Links that origin at this Context"))
 
-(defprotocol Router
+;; NOTE: node is generally considered a Graph protocol but since I am not sure
+;; about the future extensibility of it I will leave it like that
+(defprotocol Dijkstra
   "An instance used to direct the movement of Dijkstra's traversal algorithm"
   #_(seed  [this] ;TODO
-      "returns a sequence of [Node Valuable] that will be ")
+           "returns a sequence of [Node Valuable] that will be ")
   (node [this key])
   (relax [this arc trail]
     "attempts to relax node following trail path. Returns a Valuable implementation"))

--- a/src/hiposfer/kamal/network/core.clj
+++ b/src/hiposfer/kamal/network/core.clj
@@ -1,6 +1,4 @@
 (ns hiposfer.kamal.network.core
-  "An implementation of the Graph protocols oriented towards
-  Road Networks. See Graph namespace for more information"
   (:require [hiposfer.kamal.network.algorithms.protocols :as np])
   (:import (clojure.lang APersistentMap IPersistentVector)
            (ch.hsr.geohash GeoHash)))

--- a/src/hiposfer/kamal/services/routing/core.clj
+++ b/src/hiposfer/kamal/services/routing/core.clj
@@ -3,7 +3,8 @@
             [com.stuartsierra.component :as component]
             [hiposfer.kamal.io.edn :as edn]
             [hiposfer.kamal.io.gtfs :as gtfs]
-            [hiposfer.gtfs.edn :as gtfs.edn]))
+            [hiposfer.gtfs.edn :as gtfs.edn]
+            [hiposfer.kamal.services.routing.graph :as graph]))
 
 ;; NOTE: we use :db/index true to replace the lack of :VAET index in datascript
 ;; This is for performance. In lots of cases we want to lookup back-references
@@ -51,7 +52,10 @@
   "builds a datascript in-memory db and conj's it into the passed agent"
   [area]
   ;; re-build the network from the file
-  (data/conn-from-db (edn/parse (:area/edn area))))
+  (let [db   (edn/parse (:area/edn area))
+        conn (data/conn-from-db db)]
+    (alter-meta! conn assoc :area/graph (graph/create db))
+    conn))
 
 (defn- stop-process
   [agnt error]

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -214,9 +214,10 @@
       (let [router     (transit/->TransitRouter network trips)
             ; both start and dst should be found since we checked that before
             traversal  (alg/dijkstra router
-                                     #{[src (. start (getSeconds))]})
-            rtrail     (alg/shortest-path dst traversal)]
-        (when (some? rtrail)
+                                     #{[(:db/id src) (. start (getSeconds))]})
+            rtrail     (alg/shortest-path (:db/id dst) traversal)
+            rtrail     (for [[id value] rtrail] (first {(data/entity network id) value}))]
+        (when (not-empty rtrail)
           (merge
             {:directions/uuid      (data/squuid)
              :directions/waypoints

--- a/src/hiposfer/kamal/services/routing/graph.clj
+++ b/src/hiposfer/kamal/services/routing/graph.clj
@@ -59,15 +59,15 @@
 
 (defn- edge
   [entity]
-  (map->Edge {:src (:db/id (:edge/src entity))
-              :dst (:db/id (:edge/dst entity))
-              :way (:db/id (:edge/way entity))}))
+  (map->Edge {:src   (:db/id (:edge/src entity))
+              :dst   (:db/id (:edge/dst entity))
+              :way/e (:db/id (:edge/way entity))}))
 
 (defn- arc
   [entity]
-  (map->Arc {:src (:db/id (:arc/src entity))
-             :dst (:db/id (:arc/dst entity))
-             :route (:db/id (:arc/route entity))}))
+  (map->Arc {:src     (:db/id (:arc/src entity))
+             :dst     (:db/id (:arc/dst entity))
+             :route/e (:db/id (:arc/route entity))}))
 
 (defn- node-edges
   [network id]
@@ -104,4 +104,8 @@
 
 #_(time
     (let [network @(first @(:networks (:router hiposfer.kamal.dev/system)))]
-      (create network)))
+      (last (::foo (assoc network ::foo (create network))))))
+
+(defn osm-node? [o] (instance? PedestrianNode o))
+
+(defn gtfs-stop? [o] (instance? TransitStop o))

--- a/src/hiposfer/kamal/services/routing/graph.clj
+++ b/src/hiposfer/kamal/services/routing/graph.clj
@@ -1,0 +1,54 @@
+(ns hiposfer.kamal.services.routing.graph
+  (:require [hiposfer.kamal.network.algorithms.protocols :as np]
+            [datascript.core :as data]))
+
+(defn edge? [o] (and (satisfies? np/Arc o)
+                     (satisfies? np/Bidirectional o)))
+
+(defn arc? [o] (satisfies? np/Arc o))
+
+(defn node? [o] (satisfies? np/Node o))
+
+;; A bidirectional Arc. The bidirectionality is represented
+;; through a mirror Arc, which is created as requested at runtime
+(defrecord PedestrianEdge [^long src ^long dst ^long way]
+  np/Arc
+  (src [_] src)
+  (dst [_] dst)
+  np/Bidirectional
+  (mirror [this]
+    (if (:mirror? this)
+      (dissoc this :mirror?) ; remove mirror from edge
+      (map->PedestrianEdge {:src dst :dst src :way way :mirror? true})))
+  (mirror? [this] (:mirror? this)))
+
+;; A directed arc with an associated way; as per Open Street Maps
+(defrecord Arc [^long src ^long dst]
+  np/Arc
+  (src [_] src)
+  (dst [_] dst))
+
+;; A node of a graph with a corresponding position using the World Geodesic
+;; System. This implementation only accepts edges (bidirectional)
+(defrecord PedestrianNode [^Long id location edges]
+  np/Node
+  (successors [_]
+    (for [edge edges]
+      (if (= id (np/dst edge)) edge
+        (np/mirror edge)))))
+
+(defrecord TransitStop [^Long id ^Double lat ^Double lon arcs edges]
+  np/GeoCoordinate
+  (lat [_] lat)
+  (lon [_] lon)
+  np/Node
+  (successors [this]
+    (concat (:outgoing this)
+            (for [edge edges]
+              (if (= id (np/dst edge)) edge
+                (np/mirror edge))))))
+
+#_(let [network @(first @(:networks (:router hiposfer.kamal.dev/system)))]
+    (for [node-id (data/datoms network :avet :node/id)
+          :let [node (data/entity network (:e node-id))]]
+      [(:e node-id) ()]))

--- a/src/hiposfer/kamal/services/routing/graph.clj
+++ b/src/hiposfer/kamal/services/routing/graph.clj
@@ -1,6 +1,9 @@
 (ns hiposfer.kamal.services.routing.graph
-  (:require [hiposfer.kamal.network.algorithms.protocols :as np]
-            [datascript.core :as data]))
+  (:require [datascript.core :as data]
+            [clojure.data.int-map :as i]
+            [hiposfer.kamal.libs.fastq :as fastq]
+            [hiposfer.kamal.network.algorithms.protocols :as np]))
+
 
 (defn edge? [o] (and (satisfies? np/Arc o)
                      (satisfies? np/Bidirectional o)))
@@ -11,15 +14,13 @@
 
 ;; A bidirectional Arc. The bidirectionality is represented
 ;; through a mirror Arc, which is created as requested at runtime
-(defrecord PedestrianEdge [^long src ^long dst ^long way]
+(defrecord PedestrianEdge [^long src ^long dst]
   np/Arc
   (src [_] src)
   (dst [_] dst)
   np/Bidirectional
   (mirror [this]
-    (if (:mirror? this)
-      (dissoc this :mirror?) ; remove mirror from edge
-      (map->PedestrianEdge {:src dst :dst src :way way :mirror? true})))
+    (map->PedestrianEdge (merge this {:src dst :dst src :mirror? (not (:mirror this))})))
   (mirror? [this] (:mirror? this)))
 
 ;; A directed arc with an associated way; as per Open Street Maps
@@ -34,21 +35,66 @@
   np/Node
   (successors [_]
     (for [edge edges]
-      (if (= id (np/dst edge)) edge
-        (np/mirror edge)))))
+      (if (= id (np/dst edge))
+        (np/mirror edge)
+        edge))))
 
-(defrecord TransitStop [^Long id ^Double lat ^Double lon arcs edges]
+(defrecord TransitStop [^Long id ^Double lat ^Double lon links]
   np/GeoCoordinate
   (lat [_] lat)
   (lon [_] lon)
   np/Node
-  (successors [this]
-    (concat (:outgoing this)
-            (for [edge edges]
-              (if (= id (np/dst edge)) edge
-                (np/mirror edge))))))
+  (successors [_]
+    (for [link links]
+      (if (and (edge? link) (= id (np/dst link)))
+        (np/mirror link)
+        link))))
 
-#_(let [network @(first @(:networks (:router hiposfer.kamal.dev/system)))]
-    (for [node-id (data/datoms network :avet :node/id)
-          :let [node (data/entity network (:e node-id))]]
-      [(:e node-id) ()]))
+(defn- edge
+  [entity]
+  (map->PedestrianEdge {:src (:db/id (:edge/src entity))
+                        :dst (:db/id (:edge/dst entity))
+                        :way (:db/id (:edge/way entity))}))
+
+(defn- arc
+  [entity]
+  (map->Arc {:src (:db/id (:arc/src entity))
+             :dst (:db/id (:arc/dst entity))
+             :route (:db/id (:arc/route entity))}))
+
+(defn- node-edges
+  [network id]
+  (map edge (concat (fastq/references network :edge/src id)
+                    (fastq/references network :edge/dst id))))
+
+(defn- stop-links
+  [network id]
+  (concat (map arc (fastq/references network :arc/src id))
+          (map edge (fastq/references network :edge/dst id))))
+
+(defn- nodes
+  [network]
+  (for [node-id (data/datoms network :avet :node/id)
+        :let [node (data/entity network (:e node-id))]]
+    [(:e node-id) (->PedestrianNode (:e node-id)
+                                    (:node/location node)
+                                    (node-edges network (:e node-id)))]))
+
+(defn- stops
+  [network]
+  (for [stop-id (data/datoms network :avet :stop/id)
+        :let [stop (data/entity network (:e stop-id))]]
+    [(:e stop-id) (->TransitStop (:e stop-id)
+                                 (:stop/lat stop)
+                                 (:stop/lon stop)
+                                 (stop-links network (:e stop-id)))]))
+
+(defn create
+  [network]
+  (into (i/int-map)
+        (concat (nodes network)
+                (stops network))))
+
+#_(time
+    (let [network @(first @(:networks (:router hiposfer.kamal.dev/system)))]
+      (create network)))

--- a/test/hiposfer/kamal/network/road.clj
+++ b/test/hiposfer/kamal/network/road.clj
@@ -16,7 +16,7 @@
 (defspec ^:integration routing-directions
   30; tries -> expensive test
   (let [conn  (deref network) ;; force
-        nodes (alg/nodes conn)
+        nodes (alg/nodes @conn)
         gc    (count nodes)]
     (prop/for-all [i (gen/large-integer* {:min 0 :max (Math/ceil (/ gc 2))})]
       (let [src      (dir/->coordinates (:node/location (nth nodes i)))

--- a/test/hiposfer/kamal/network/road.clj
+++ b/test/hiposfer/kamal/network/road.clj
@@ -1,14 +1,14 @@
 (ns hiposfer.kamal.network.road
-  (:require [clojure.test.check.properties :as prop]
-            [clojure.test.check.clojure-test :refer [defspec]]
-            [clojure.test.check.generators :as gen]
+  (:require [clojure.spec.alpha :as s]
+            [expound.alpha :as expound]
             [clojure.test :refer [is deftest]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [hiposfer.kamal.specs.directions :as dataspecs]
             [hiposfer.kamal.network.algorithms.core :as alg]
             [hiposfer.kamal.services.routing.core :as router]
-            [clojure.spec.alpha :as s]
-            [hiposfer.kamal.specs.directions :as dataspecs]
-            [hiposfer.kamal.services.routing.directions :as dir]
-            [expound.alpha :as expound]))
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [hiposfer.kamal.services.routing.directions :as dir]))
 
 (defonce network (delay (time (router/network {:area/edn "resources/test/frankfurt.edn.gz"}))))
 

--- a/test/hiposfer/kamal/network/road.clj
+++ b/test/hiposfer/kamal/network/road.clj
@@ -17,13 +17,14 @@
   30; tries -> expensive test
   (let [conn  (deref network) ;; force
         nodes (alg/nodes @conn)
-        gc    (count nodes)]
+        gc    (count nodes)
+        graph (graph/create @conn)]
+    (alter-meta! conn assoc :area/graph graph)
     (prop/for-all [i (gen/large-integer* {:min 0 :max (Math/ceil (/ gc 2))})]
       (let [src      (dir/->coordinates (:node/location (nth nodes i)))
             dst      (dir/->coordinates (:node/location (nth nodes (* 2 i))))
             depart   (gen/generate (s/gen ::dataspecs/departure))
             args     {:coordinates [src dst] :departure depart :steps true}
-            _        (alter-meta! conn assoc :area/graph (graph/create @conn))
             result   (dir/direction conn args)]
         (if (nil? result)
           (do (println "no path found")

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -69,7 +69,7 @@
   (successors [this]
     (let [db (data/entity-db this)]
       (map #(data/entity db (:e %))
-           (data/datoms db :avet :edge/src (:db/id this))))))
+            (data/datoms db :avet :edge/src (:db/id this))))))
 
 (defrecord RosettaRouter [network]
   np/Dijkstra
@@ -108,7 +108,7 @@
            traversal)
         "shortest path doesnt traverse expected nodes")))
 
-(defrecord PedestrianRouter [network]
+(defrecord PedestrianDatascriptRouter [network]
   np/Dijkstra
   (node [this k] (data/entity network k))
   (relax [this arc trail]
@@ -130,7 +130,7 @@
     (let [graph    (fake-area/graph size)
           src      (:db/id (rand-nth (alg/nodes graph)))
           dst      (:db/id (rand-nth (alg/nodes graph)))
-          router   (->PedestrianRouter graph)
+          router   (->PedestrianDatascriptRouter graph)
           coll     (alg/dijkstra router #{src})
           results  (for [_ (range 10)]
                      (alg/shortest-path dst coll))]
@@ -148,7 +148,7 @@
      (let [graph    (fake-area/graph size)
            src      (:db/id (rand-nth (alg/nodes graph)))
            dst      (:db/id (rand-nth (alg/nodes graph)))
-           router   (->PedestrianRouter graph)
+           router   (->PedestrianDatascriptRouter graph)
            coll     (alg/dijkstra router #{src})
            result   (alg/shortest-path dst coll)]
        (is (or (nil? result)
@@ -165,7 +165,7 @@
   (prop/for-all [size (gen/large-integer* {:min 10 :max 20})]
     (let [graph    (fake-area/graph size)
           src      (:db/id (rand-nth (alg/nodes graph)))
-          router   (->PedestrianRouter graph)
+          router   (->PedestrianDatascriptRouter graph)
           coll     (alg/dijkstra router #{src})
           result   (alg/shortest-path src coll)]
       (is (not-empty result)
@@ -180,10 +180,10 @@
     100; tries
     (prop/for-all [size (gen/large-integer* {:min 10 :max 20})]
       (let [graph   (fake-area/graph size)
-            router  (->PedestrianRouter graph)
+            router  (->PedestrianDatascriptRouter graph)
             r1      (alg/looners graph router)
             graph2  (data/db-with graph (for [i r1 ] [:db.fn/retractEntity (:db/id i)]))
-            router2 (->PedestrianRouter graph2)
+            router2 (->PedestrianDatascriptRouter graph2)
             r2      (alg/looners graph2 router2)]
         (is (empty? r2)
             "looners should be empty for a strongly connected graph"))))
@@ -198,11 +198,11 @@
     100; tries
     (prop/for-all [size (gen/large-integer* {:min 10 :max 20})]
       (let [graph   (fake-area/graph size)
-            router  (->PedestrianRouter graph)
+            router  (->PedestrianDatascriptRouter graph)
             r1      (alg/looners graph router)
             graph2  (data/db-with graph (for [i r1 ] [:db.fn/retractEntity (:db/id i)]))
             src     (rand-nth (alg/nodes graph2))
-            router  (->PedestrianRouter graph2)
+            router  (->PedestrianDatascriptRouter graph2)
             coll    (alg/dijkstra router #{src})]
         (is (seq? (reduce (fn [r v] v) nil coll))
             "biggest components should not contain links to nowhere"))))

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -12,7 +12,8 @@
             [hiposfer.kamal.services.routing.transit :as transit]
             [hiposfer.kamal.services.routing.directions :as dir]
             [expound.alpha :as expound]
-            [datascript.core :as data])
+            [datascript.core :as data]
+            [hiposfer.kamal.services.routing.graph :as graph])
   (:import (datascript.impl.entity Entity)))
 
 ;; Example taken from
@@ -213,7 +214,9 @@
   (prop/for-all [size (gen/large-integer* {:min 10 :max 20})]
     (let [graph    (fake-area/graph size)
           request  (gen/generate (s/gen ::dataspecs/params))
-          result   (dir/direction graph request)]
+          conn     (data/conn-from-db graph)
+          _        (alter-meta! conn assoc :area/graph (graph/create graph))
+          result   (dir/direction conn request)]
       (is (s/valid? ::dataspecs/directions result)
           (str (expound/expound-str ::dataspecs/directions result))))))
 

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -1,18 +1,18 @@
 (ns hiposfer.kamal.network.tests
-  (:require [clojure.test.check.properties :as prop]
-            [clojure.test.check.clojure-test :refer [defspec]]
-            [clojure.test.check.generators :as gen]
+  (:require [clojure.spec.alpha :as s]
             [clojure.test :refer [is deftest]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [clojure.test.check.clojure-test :refer [defspec]]
             [hiposfer.kamal.network.algorithms.core :as alg]
             [hiposfer.kamal.network.algorithms.protocols :as np]
-            [datascript.core :as data]
             [hiposfer.kamal.services.routing.core :as router]
-            [clojure.spec.alpha :as s]
             [hiposfer.kamal.network.generators :as fake-area]
             [hiposfer.kamal.specs.directions :as dataspecs]
             [hiposfer.kamal.services.routing.transit :as transit]
             [hiposfer.kamal.services.routing.directions :as dir]
-            [expound.alpha :as expound]))
+            [expound.alpha :as expound]
+            [datascript.core :as data]))
 
 ;; Example taken from
 ;; https://rosettacode.org/wiki/Dijkstra%27s_algorithm

--- a/test/hiposfer/kamal/network/tests.clj
+++ b/test/hiposfer/kamal/network/tests.clj
@@ -15,16 +15,6 @@
             [datascript.core :as data])
   (:import (datascript.impl.entity Entity)))
 
-(extend-type Entity
-  np/Arc
-  (src [this] (:db/id (:edge/src this)))
-  (dst [this] (:db/id (:edge/dst this)))
-  np/Node
-  (successors [this]
-    (let [db (data/entity-db this)]
-      (map #(data/entity db (:e %))
-            (data/datoms db :avet :edge/src (:db/id this))))))
-
 ;; Example taken from
 ;; https://rosettacode.org/wiki/Dijkstra%27s_algorithm
 ;; we assume bidirectional links
@@ -69,6 +59,16 @@
 ;; --- bidirectional arcs ... see kotlin solution
 ;Distances from 1: ((1 0) (2 7) (3 9) (4 20) (5 20) (6 11))
 ;Shortest path: (1 3 6 5)
+
+(extend-type Entity
+  np/Arc
+  (src [this] (:db/id (:edge/src this)))
+  (dst [this] (:db/id (:edge/dst this)))
+  np/Node
+  (successors [this]
+    (let [db (data/entity-db this)]
+      (map #(data/entity db (:e %))
+           (data/datoms db :avet :edge/src (:db/id this))))))
 
 (defrecord RosettaRouter [network]
   np/Dijkstra


### PR DESCRIPTION
- fixes #244 

## implementation details
Datascript is an incredibly flexible tool, however the more flexible a tool is, the slower it is since it has to double check more things or organize things in different ways to support that flexibility.

This PR changes the way we do routing. Instead of directly using Datascript, we use an Integer-optimized Map representation. Basically we switch to a standard graph representation for routing. This is to support the topmost performance. Our pedestrian routing is now more than 9 times faster than before, the Transit routing is around half the time as before and I expect this to decrease once #224 lands.

The price of this performance boost is redundancy. The graph representation mirrors Datascript data but it doesnt contain it all. It only contains the parts that are very performance sensitive (lookups, locations and edge/arcs). The rest still lives in Datascript. However, even if we would want to, replacing Datascript with a graph representation would be too difficult as GTFS data cannot be represented in the same way.

Through VisualVM I concluded that the extra storage required for the mirror graph is around 30 MB which I think is acceptable considering that Datascript is around 230 MB.