### PR TITLE
frequencies.txt support added

### DIFF
--- a/resources/benchmark.txt
+++ b/resources/benchmark.txt
@@ -1,64 +1,72 @@
 
 Testing hiposfer.kamal.network.benchmark
-"Elapsed time: 18510.606777 msecs"
+"Elapsed time: 4573.923139 msecs"
 
 
 Road network: nearest neighbour search with random src/dst
-B+ tree with: 1991267 nodes
+B+ tree with: 423937 nodes
 accuracy:  14.397657786540089 meters
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.0 -Dclojure.debug=false
-Evaluation count : 25980 in 6 samples of 4330 calls.
-      Execution time sample mean : 22.501947 µs
-             Execution time mean : 22.495338 µs
-Execution time sample std-deviation : 441.677542 ns
-    Execution time std-deviation : 486.365532 ns
-   Execution time lower quantile : 22.013828 µs ( 2.5%)
-   Execution time upper quantile : 23.003327 µs (97.5%)
-                   Overhead used : 1.814603 ns
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.1 -Dclojure.debug=false
+Evaluation count : 29136 in 6 samples of 4856 calls.
+      Execution time sample mean : 20.861272 µs
+             Execution time mean : 20.874462 µs
+Execution time sample std-deviation : 430.261411 ns
+    Execution time std-deviation : 434.396701 ns
+   Execution time lower quantile : 20.537877 µs ( 2.5%)
+   Execution time upper quantile : 21.589133 µs (97.5%)
+                   Overhead used : 1.796905 ns
+
+Found 1 outliers in 6 samples (16.6667 %)
+	low-severe	 1 (16.6667 %)
+ Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
 
 
 Pedestrian routing with: 50915 nodes
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.0 -Dclojure.debug=false
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.1 -Dclojure.debug=false
 Evaluation count : 18 in 6 samples of 3 calls.
-      Execution time sample mean : 39.929551 ms
-             Execution time mean : 39.875935 ms
-Execution time sample std-deviation : 1.331996 ms
-    Execution time std-deviation : 1.407142 ms
-   Execution time lower quantile : 38.142296 ms ( 2.5%)
-   Execution time upper quantile : 41.308428 ms (97.5%)
-                   Overhead used : 1.814603 ns
+      Execution time sample mean : 38.660907 ms
+             Execution time mean : 38.635912 ms
+Execution time sample std-deviation : 944.481921 µs
+    Execution time std-deviation : 1.066157 ms
+   Execution time lower quantile : 37.214196 ms ( 2.5%)
+   Execution time upper quantile : 39.886597 ms (97.5%)
+                   Overhead used : 1.796905 ns
 
 
 Transit routing with: 50915 nodes
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.0 -Dclojure.debug=false
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.1 -Dclojure.debug=false
 Evaluation count : 6 in 6 samples of 1 calls.
-      Execution time sample mean : 384.816759 ms
-             Execution time mean : 384.919578 ms
-Execution time sample std-deviation : 6.690093 ms
-    Execution time std-deviation : 6.926220 ms
-   Execution time lower quantile : 377.719763 ms ( 2.5%)
-   Execution time upper quantile : 395.156839 ms (97.5%)
-                   Overhead used : 1.814603 ns
+      Execution time sample mean : 130.607274 ms
+             Execution time mean : 130.707615 ms
+Execution time sample std-deviation : 3.391188 ms
+    Execution time std-deviation : 3.439405 ms
+   Execution time lower quantile : 126.827610 ms ( 2.5%)
+   Execution time upper quantile : 135.953964 ms (97.5%)
+                   Overhead used : 1.796905 ns
+
+Found 1 outliers in 6 samples (16.6667 %)
+	low-severe	 1 (16.6667 %)
+ Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
 
 
-DIJKSTRA forward with: 1021 nodes
+DIJKSTRA forward with: 1014 nodes
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.0 -Dclojure.debug=false
-Evaluation count : 228462 in 6 samples of 38077 calls.
-      Execution time sample mean : 2.680761 µs
-             Execution time mean : 2.678805 µs
-Execution time sample std-deviation : 39.775613 ns
-    Execution time std-deviation : 42.710638 ns
-   Execution time lower quantile : 2.619540 µs ( 2.5%)
-   Execution time upper quantile : 2.716540 µs (97.5%)
-                   Overhead used : 1.814603 ns
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.1 -Dclojure.debug=false
+Evaluation count : 240108 in 6 samples of 40018 calls.
+      Execution time sample mean : 2.524666 µs
+             Execution time mean : 2.524742 µs
+Execution time sample std-deviation : 26.900295 ns
+    Execution time std-deviation : 28.511805 ns
+   Execution time lower quantile : 2.498645 µs ( 2.5%)
+   Execution time upper quantile : 2.557943 µs (97.5%)
+                   Overhead used : 1.796905 ns
 
 Ran 4 tests containing 0 assertions.
 0 failures, 0 errors.

--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -152,7 +152,7 @@
       (and (empty? cycle-trips) (seq fixed-time-trips))
       (apply min-key :value fixed-time-trips)
 
-      :else
+      (and (seq cycle-trips) (seq fixed-time-trips))
       (apply min-key :value (concat cycle-trips fixed-time-trips)))))
 
 ;; src - [:stop/id 3392140086]

--- a/src/hiposfer/kamal/libs/fastq.clj
+++ b/src/hiposfer/kamal/libs/fastq.clj
@@ -83,6 +83,7 @@
   [network ?trip-id ?src-id ?dst-id]
   (let [datoms (data/datoms network :avet :stop_time/trip ?trip-id)
         start  (data/entity network (:e (first datoms)))]
+    ;; TODO: is there any guarantee that the first datom is the start of the trip ?
     (cons start
       (for [d datoms
             :let [stop_time (data/entity network (:e d))]
@@ -119,7 +120,8 @@
                                (data/datoms network :avet :stop_time/stop ?src-id))]
       (when (seq stop_times)
         (let [from (apply min-key :stop_time/departure_time stop_times)
-              to   (continue-fixed-time-trip network ?dst-id (:stop_time/trip from))]
+              to   (tool/some #(= ?dst-id (:db/id (:stop_time/stop %)))
+                               (references network :stop_time/trip (:db/id (:stop_time/trip from))))]
           (when (some? to)
             {:value          (:stop_time/arrival_time to)
              :stop_time/from from

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -66,7 +66,7 @@
 
       ;; taking a trip on a public transport vehicle
       "continue" ;; only applies to transit
-      (let [tstart  (:start (val (first piece)))
+      (let [tstart  (:stop_time/from (val (first piece)))
             route   (:trip/route (:stop_time/trip tstart))
             vehicle (transit/route-types (:route/type route))
             id      (str vehicle " " (or (:route/short_name route)
@@ -74,7 +74,7 @@
         (str "Continue on " id))
 
       "notification"
-      (let [tend    (:start (val (first piece)))
+      (let [tend    (:stop_time/from (val (first piece)))
             trip    (:stop_time/trip tend)
             route   (:trip/route trip)
             vehicle (transit/route-types (:route/type route))
@@ -160,8 +160,8 @@
         {:step/departure (+ start departs)})
       (when (= "transit" mode)
         (if (= "exit vehicle" (:maneuver/type man))
-          (gtfs/resource (:end (val (first piece))))
-          (gtfs/resource (:start (val (first piece)))))))))
+          (gtfs/resource (:stop_time/to (val (first piece))))
+          (gtfs/resource (:stop_time/from (val (first piece)))))))))
 
 (defn- route-steps
   "returns a route-steps vector or an empty vector if no steps are needed"
@@ -224,9 +224,9 @@
           (merge
             {:directions/uuid      (data/squuid)
              :directions/waypoints
-             [{:waypoint/name     (:way/name (:way (val (first trail))))
+             [{:waypoint/name     (:way/name (:way/entity (val (first trail))))
                :waypoint/location (->coordinates (location src))}
-              {:waypoint/name     (:way/name (:way (val (last trail))))
+              {:waypoint/name     (:way/name (:way/entity (val (last trail))))
                :waypoint/location (->coordinates (location dst))}]}
             (route network trail (-> departure (.truncatedTo ChronoUnit/DAYS)
                                                (.toEpochSecond)))))))))
@@ -238,3 +238,7 @@
                                   ;[8.699619, 50.097842]] ;; sachsenhausen
                                   [8.635897, 50.104172]] ;; galluswarte
                     :departure (ZonedDateTime/parse "2018-05-07T10:15:30+02:00")}))
+
+#_(let [network @(first @(:networks (:router hiposfer.kamal.dev/system)))]
+    (for [d (data/datoms network :avet :frequency/trip)]
+      (data/touch (data/entity network (:e d)))))

--- a/src/hiposfer/kamal/services/routing/directions.clj
+++ b/src/hiposfer/kamal/services/routing/directions.clj
@@ -238,7 +238,3 @@
                                   ;[8.699619, 50.097842]] ;; sachsenhausen
                                   [8.635897, 50.104172]] ;; galluswarte
                     :departure (ZonedDateTime/parse "2018-05-07T10:15:30+02:00")}))
-
-#_(let [network @(first @(:networks (:router hiposfer.kamal.dev/system)))]
-    (for [d (data/datoms network :avet :frequency/trip)]
-      (data/touch (data/entity network (:e d)))))

--- a/src/hiposfer/kamal/services/routing/transit.clj
+++ b/src/hiposfer/kamal/services/routing/transit.clj
@@ -82,23 +82,19 @@
         ;; riding on public transport .............
         ;; the user is already in a trip. Just find the trip going to dst [stop stop]
         (trip-cost? value)
-        (let [trip (:stop_time/trip (:stop_time/from value))
-              st   (fastq/continue-trip network dst-id trip)]
-          (when (some? st)
-            (map->TripCost {:value          (:stop_time/arrival_time st)
-                            :stop_time/from (:stop_time/to value)
-                            :stop_time/to   st})))
+        (let [trip   (:stop_time/trip (:stop_time/from value))
+              result (fastq/continue-trip network value dst-id)]
+          (when (some? result)
+            (map->TripCost result)))
 
         ;; the user is trying to get on a vehicle - find the next trip
         :else
         (let [route       (:route/e arc)
               route-trips (map :e (data/datoms network :avet :trip/route route))
               local-trips (set/intersection (set route-trips) trips)
-              [st1 st2]   (fastq/find-trip network local-trips src-id dst-id now)]
-          (when (some? st2) ;; nil if no trip was found
-            (map->TripCost {:value          (:stop_time/arrival_time st2)
-                            :stop_time/from st1
-                            :stop_time/to   st2})))))))
+              result      (fastq/find-trip network local-trips src-id dst-id now)]
+          (when (some? result) ;; nil if no trip was found
+            (map->TripCost result)))))))
 
 (defn name
   "returns a name that represents this entity in the network.


### PR DESCRIPTION
- fixes #224 
- cosmetic changes
- NOTE: since it is not possible anymore to identify a trip by its stop_time, we would need to change the response from kamal. That is still a TODO

This PR not only adds support for frequencies.txt but also greatly improves the performance of kamal when using such a feed; since those are more compact and easier to traverse. Therefore the following improvements arise:
- decrease for reading a preprocessed dump from 18 seconds to 5
- decrease for routing from 400 ms to 130 ms

### implementation notes - overview
- lookup the trips connecting two stops
- find if they are defined in frequencies.txt
- find any fixed-time trips defined in stop_times.txt
- compute the minimum of all of them
- use previous result when continuing on board of a trip
- repeat :)