### PR TITLE
avoid duplicating data

### DIFF
--- a/resources/benchmark.txt
+++ b/resources/benchmark.txt
@@ -1,68 +1,69 @@
 
 Testing hiposfer.kamal.router.benchmark
-"Elapsed time: 4962.177982 msecs"
+"Elapsed time: 4960.452239 msecs"
+"Elapsed time: 7978.679925 msecs"
 
 
 Road network: nearest neighbour search with random src/dst
-B+ tree with: 423937 nodes
+B+ tree with: 239111 nodes
 accuracy:  14.397657786540089 meters
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.1 -Dclojure.debug=false
-Evaluation count : 27162 in 6 samples of 4527 calls.
-      Execution time sample mean : 22.349489 µs
-             Execution time mean : 22.352483 µs
-Execution time sample std-deviation : 593.211301 ns
-    Execution time std-deviation : 594.180254 ns
-   Execution time lower quantile : 22.034206 µs ( 2.5%)
-   Execution time upper quantile : 23.378569 µs (97.5%)
-                   Overhead used : 1.799125 ns
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.19.0 -Dclojure.debug=false
+Evaluation count : 25608 in 6 samples of 4268 calls.
+      Execution time sample mean : 23.980990 µs
+             Execution time mean : 23.975979 µs
+Execution time sample std-deviation : 794.170191 ns
+    Execution time std-deviation : 798.337098 ns
+   Execution time lower quantile : 23.411626 µs ( 2.5%)
+   Execution time upper quantile : 25.184774 µs (97.5%)
+                   Overhead used : 1.880327 ns
+
+
+Pedestrian routing with: 50915 nodes
+x86_64 Mac OS X 10.13.6 8 cpu(s)
+Java HotSpot(TM) 64-Bit Server VM 25.101-b13
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.19.0 -Dclojure.debug=false
+Evaluation count : 18 in 6 samples of 3 calls.
+      Execution time sample mean : 35.760761 ms
+             Execution time mean : 35.740752 ms
+Execution time sample std-deviation : 836.826648 µs
+    Execution time std-deviation : 841.568044 µs
+   Execution time lower quantile : 34.062295 ms ( 2.5%)
+   Execution time upper quantile : 36.194013 ms (97.5%)
+                   Overhead used : 1.880327 ns
 
 Found 1 outliers in 6 samples (16.6667 %)
 	low-severe	 1 (16.6667 %)
  Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
 
 
-Pedestrian routing with: 50915 nodes
-x86_64 Mac OS X 10.13.6 8 cpu(s)
-Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.1 -Dclojure.debug=false
-Evaluation count : 18 in 6 samples of 3 calls.
-      Execution time sample mean : 41.666909 ms
-             Execution time mean : 41.644226 ms
-Execution time sample std-deviation : 694.568908 µs
-    Execution time std-deviation : 739.240943 µs
-   Execution time lower quantile : 40.674140 ms ( 2.5%)
-   Execution time upper quantile : 42.320290 ms (97.5%)
-                   Overhead used : 1.799125 ns
-
-
 Transit routing with: 50915 nodes
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.1 -Dclojure.debug=false
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.19.0 -Dclojure.debug=false
 Evaluation count : 6 in 6 samples of 1 calls.
-      Execution time sample mean : 125.068624 ms
-             Execution time mean : 125.057520 ms
-Execution time sample std-deviation : 3.474232 ms
-    Execution time std-deviation : 3.611091 ms
-   Execution time lower quantile : 121.027470 ms ( 2.5%)
-   Execution time upper quantile : 129.940304 ms (97.5%)
-                   Overhead used : 1.799125 ns
+      Execution time sample mean : 117.128611 ms
+             Execution time mean : 117.124083 ms
+Execution time sample std-deviation : 2.573390 ms
+    Execution time std-deviation : 2.789097 ms
+   Execution time lower quantile : 113.899287 ms ( 2.5%)
+   Execution time upper quantile : 120.054286 ms (97.5%)
+                   Overhead used : 1.880327 ns
 
 
-DIJKSTRA forward with: 1022 nodes
+DIJKSTRA forward with: 1019 nodes
 x86_64 Mac OS X 10.13.6 8 cpu(s)
 Java HotSpot(TM) 64-Bit Server VM 25.101-b13
-Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.18.1 -Dclojure.debug=false
-Evaluation count : 295992 in 6 samples of 49332 calls.
-      Execution time sample mean : 2.069178 µs
-             Execution time mean : 2.069178 µs
-Execution time sample std-deviation : 56.861623 ns
-    Execution time std-deviation : 58.733517 ns
-   Execution time lower quantile : 2.020867 µs ( 2.5%)
-   Execution time upper quantile : 2.143718 µs (97.5%)
-                   Overhead used : 1.799125 ns
+Runtime arguments: -Dfile.encoding=UTF-8 -XX:-OmitStackTraceInFastThrow -Dclojure.compile.path=/Users/Camilo/Proyectos/kamal/target/classes -Dkamal.version=0.19.0 -Dclojure.debug=false
+Evaluation count : 287910 in 6 samples of 47985 calls.
+      Execution time sample mean : 2.070309 µs
+             Execution time mean : 2.070509 µs
+Execution time sample std-deviation : 14.583135 ns
+    Execution time std-deviation : 14.646241 ns
+   Execution time lower quantile : 2.057235 µs ( 2.5%)
+   Execution time upper quantile : 2.091416 µs (97.5%)
+                   Overhead used : 1.880327 ns
 
 Ran 4 tests containing 0 assertions.
 0 failures, 0 errors.

--- a/src/hiposfer/kamal/preprocessor.clj
+++ b/src/hiposfer/kamal/preprocessor.clj
@@ -71,9 +71,11 @@
     (as-> (data/empty-db routing/schema) $
           (time (data/db-with $ (fetch-osm! area)))
           (time (data/db-with $ (gtfs/transaction! z)))
-          (time (data/db-with $ (fastq/link-stops $)))
-          (time (data/db-with $ (fastq/cache-stop-successors $)))
-          (time (data/db-with $ (area-transaction $ area)))))) ;; add the area as transaction
+          ;; force lazy seqs to ensure that they dont throw errors
+          (time (do (dorun (fastq/link-stops $))
+                    (dorun (fastq/cache-stop-successors $))
+                    ;; add the area as transaction
+                    (data/db-with $ (area-transaction $ area)))))))
 
 (defn -main
   "Script for preprocessing OSM and GTFS files into gzip files each with

--- a/src/hiposfer/kamal/router/algorithms/protocols.clj
+++ b/src/hiposfer/kamal/router/algorithms/protocols.clj
@@ -31,3 +31,10 @@
   (node [this key])
   (relax [this arc trail]
     "attempts to relax node following trail path. Returns a Valuable implementation"))
+
+(defn edge? [o] (and (satisfies? Arc o)
+                     (satisfies? Bidirectional o)))
+
+(defn arc? [o] (satisfies? Arc o))
+
+(defn node? [o] (satisfies? Node o))

--- a/src/hiposfer/kamal/router/core.clj
+++ b/src/hiposfer/kamal/router/core.clj
@@ -47,7 +47,7 @@
   ;; re-build the network from the file
   (let [db   (edn/parse (:area/edn area))
         conn (data/conn-from-db db)]
-    (alter-meta! conn assoc :area/graph (graph/create db))
+    (alter-meta! conn assoc :area/graph (time (graph/create db)))
     conn))
 
 (defn- stop-process

--- a/src/hiposfer/kamal/router/graph.clj
+++ b/src/hiposfer/kamal/router/graph.clj
@@ -119,10 +119,6 @@
           (concat (nodes db (group-by np/src edges) edges-to)
                   (stops db edges-to (group-by np/src arcs))))))
 
-#_(time
-    (let [network @(first @(:networks (:router hiposfer.kamal.dev/system)))]
-      (last (::foo (assoc network ::foo (create network))))))
-
 (defn node? [o] (instance? PedestrianNode o))
 
 (defn stop? [o] (instance? TransitStop o))

--- a/src/hiposfer/kamal/router/graph.clj
+++ b/src/hiposfer/kamal/router/graph.clj
@@ -6,14 +6,6 @@
             [hiposfer.kamal.router.util.fastq :as fastq]
             [hiposfer.kamal.router.algorithms.protocols :as np]))
 
-
-(defn edge? [o] (and (satisfies? np/Arc o)
-                     (satisfies? np/Bidirectional o)))
-
-(defn arc? [o] (satisfies? np/Arc o))
-
-(defn node? [o] (satisfies? np/Node o))
-
 ;; A bidirectional Arc. The bidirectionality is represented
 ;; through a mirror Arc, which is created as requested at runtime
 (defrecord Edge [^long src ^long dst]
@@ -53,7 +45,7 @@
   np/Node
   (successors [_]
     (for [link links]
-      (if (and (edge? link) (= id (np/dst link)))
+      (if (and (np/edge? link) (= id (np/dst link)))
         (np/mirror link)
         link))))
 

--- a/src/hiposfer/kamal/router/graph.clj
+++ b/src/hiposfer/kamal/router/graph.clj
@@ -103,9 +103,9 @@
 
   We just piggie-back on Datascript to do the hard work on resolving references"
   [network]
-  (as-> (time (data/db-with network (edges-tx network))) db
-        (time (data/db-with db (fastq/link-stops db)))
-        (time (data/db-with db (fastq/cache-stop-successors db)))))
+  (as-> (data/db-with network (edges-tx network)) db
+        (data/db-with db (fastq/link-stops db))
+        (data/db-with db (fastq/cache-stop-successors db))))
 
 (defn create
   [network]

--- a/src/hiposfer/kamal/router/io/osm.clj
+++ b/src/hiposfer/kamal/router/io/osm.clj
@@ -121,16 +121,8 @@
         ways          (trim-ways (filter :way/id nodes&ways))
         ;; post-processing nodes
         ids           (into #{} (mapcat :way/nodes) ways)
-        nodes         (filter #(contains? ids (:node/id %)) nodes&ways)
-        arcs          (for [way ways
-                            [from to] (map vector (:way/nodes way)
-                                                  (rest (:way/nodes way)))]
-                        {:edge/src [:node/id from]
-                         :edge/dst [:node/id to]
-                         :edge/way [:way/id (:way/id way)]})]
-    (concat nodes
-            (map #(dissoc % :way/nodes) ways)
-            arcs)))
+        nodes         (filter #(contains? ids (:node/id %)) nodes&ways)]
+    (concat nodes ways)))
 
 ;; https://www.wikiwand.com/en/Preferred_walking_speed
 (def walking-speed  1.4);; m/s

--- a/src/hiposfer/kamal/router/transit.clj
+++ b/src/hiposfer/kamal/router/transit.clj
@@ -68,13 +68,13 @@
       #_(println "walk?:" (walk-cost? value) "trip?:" (trip-cost? value))
       (cond
         ;; The user is just walking so we route based on walking duration
-        (graph/osm-node? src) ;; [node (or node stop)]
+        (graph/node? src) ;; [node (or node stop)]
         (map->WalkCost {:value      (Long/sum now (walk-time src dst))
                         :way/entity (data/entity network (:way/e arc))})
 
         ;; the user is trying to leave a vehicle. Apply penalty but route
         ;; normally
-        (graph/osm-node? dst) ;; [stop node]
+        (graph/node? dst) ;; [stop node]
         (map->WalkCost {:value      (Long/sum (Long/sum now penalty)
                                               (walk-time src dst))
                         :way/entity (data/entity network (:way/e arc))})

--- a/test/hiposfer/kamal/router/benchmark.clj
+++ b/test/hiposfer/kamal/router/benchmark.clj
@@ -22,7 +22,7 @@
 ;; meant to go from one place to the other, thus Dijkstra almost always fails to
 ;; finds a path (really fast)
 (test/deftest ^:benchmark A-dijkstra-random-graph
-  (let [network (fake-area/graph 1000)
+  (let [network (fake-area/osm-gen 1000)
         src     (rand-nth (kt/nodes network))
         dst     (rand-nth (kt/nodes network))
         router  (kt/->PedestrianDatascriptRouter network)]

--- a/test/hiposfer/kamal/router/generators.clj
+++ b/test/hiposfer/kamal/router/generators.clj
@@ -9,18 +9,20 @@
 
 (def string-alpha
   "Generate alpha strings"
-  (gen/fmap str/join (gen/vector gen/char-alpha)))
+  (gen/fmap str/join (gen/vector gen/char-alpha 10)))
 
 (defn fake-ways
   "returns a sequence of way objects ready to be used in a Datascript transaction"
   [ids node-ids]
   ;; An string 90% of the time, nil 10%
-  (let [namer (gen/frequency [[1 (gen/return "")]
+  (let [namer (gen/frequency [[1 (gen/return nil)]
                               [9 (gen/fmap str/capitalize string-alpha)]])]
-    (for [id ids]
-      {:way/id id
-       :way/name (gen/generate namer)
-       :way/nodes (random-sample 0.3 node-ids)})))
+    (for [id ids
+          :let [name (gen/generate namer)]]
+      (merge {:way/id id
+              :way/nodes (random-sample 0.3 node-ids)}
+             (when (some? name)
+               {:way/name name})))))
 
 (defn- fake-nodes
   "returns a graph based on the provided node ids. Random latitude and longitudes

--- a/test/hiposfer/kamal/router/generators.clj
+++ b/test/hiposfer/kamal/router/generators.clj
@@ -13,28 +13,14 @@
 
 (defn fake-ways
   "returns a sequence of way objects ready to be used in a Datascript transaction"
-  [ids]
+  [ids node-ids]
   ;; An string 90% of the time, nil 10%
   (let [namer (gen/frequency [[1 (gen/return "")]
                               [9 (gen/fmap str/capitalize string-alpha)]])]
     (for [id ids]
       {:way/id id
-       :way/name (gen/generate namer)})))
-
-(defn- fake-edges
-  [node-ids way-ids]
-  (let [node-id  #(rand-nth (seq node-ids))
-        way-id   #(rand-nth (seq way-ids))
-        arcer    #(let [src (node-id)
-                        dst (node-id)
-                        way (way-id)]
-                    (if (not= src dst)
-                      {:node/id   src
-                       :node/arcs #{{:arc/dst [:node/id dst]
-                                     :arc/way [:way/id way]}}}
-                      (recur)))]
-    ;; create 3 times as many edges as node IDs
-    (repeatedly (* 3 (count node-ids)) arcer)))
+       :way/name (gen/generate namer)
+       :way/nodes (random-sample 0.3 node-ids)})))
 
 (defn- fake-nodes
   "returns a graph based on the provided node ids. Random latitude and longitudes
@@ -46,10 +32,7 @@
       {:node/id id
        :node/location (network/->Location (lon-gen) (lat-gen))})))
 
-;; TODO: this is far from ideal. Currently we just generate nodes here
-;; and then later on we generate ways and HOPE that they match. This
-;; can lead to bugs since the generated graph is not consistent
-(defn graph
+(defn osm-gen
   "returns a graph generator with node's id between 0 and 3*size.
   The generator creates a minimum of size elements"
   [size]
@@ -58,21 +41,20 @@
         nodes (fake-nodes (gen/generate (gen/set (gen/resize (* 3 size) gen/nat)
                                                  {:min-elements size})))
         ways  (fake-ways (gen/generate (gen/set (gen/resize size gen/nat)
-                                                {:min-elements (/ size 3)})))
-        edges (fake-edges (set (map :node/id nodes))
-                          (set (map :way/id ways)))]
-    (data/db-with db (concat nodes ways edges))))
+                                                {:min-elements (/ size 3)}))
+                         (set (map :node/id nodes)))]
+    (data/db-with db (concat nodes ways))))
 
 ;; example usage
 ;(graph 100)
 
-(defn pedestrian-graph
+(defn osm
   "builds a datascript in-memory db and returns it. Only valid for
   pedestrian routing"
   ([]
-   (pedestrian-graph 100))
+   (osm 100))
   ([size]
-   (gen/fmap graph (gen/resize (* 3 size) gen/nat))))
+   (gen/fmap osm-gen (gen/resize (* 3 size) gen/nat))))
 
 ;; example usage
 ;(gen/generate (pedestrian-graph 3))

--- a/test/hiposfer/kamal/router/road.clj
+++ b/test/hiposfer/kamal/router/road.clj
@@ -8,8 +8,7 @@
             [hiposfer.kamal.server.specs.directions :as dataspecs]
             [hiposfer.kamal.router.tests :as rt]
             [hiposfer.kamal.router.core :as router]
-            [hiposfer.kamal.router.directions :as dir]
-            [hiposfer.kamal.router.graph :as graph]))
+            [hiposfer.kamal.router.directions :as dir]))
 
 (defonce network (delay (time (router/network {:area/edn "resources/test/frankfurt.edn.gz"}))))
 
@@ -17,9 +16,7 @@
   30; tries -> expensive test
   (let [conn  (deref network) ;; force
         nodes (rt/nodes @conn)
-        gc    (count nodes)
-        graph (graph/create @conn)]
-    (alter-meta! conn assoc :area/graph graph)
+        gc    (count nodes)]
     (prop/for-all [i (gen/large-integer* {:min 0 :max (Math/ceil (/ gc 2))})]
       (let [src      (dir/->coordinates (:node/location (nth nodes i)))
             dst      (dir/->coordinates (:node/location (nth nodes (* 2 i))))

--- a/test/hiposfer/kamal/router/tests.clj
+++ b/test/hiposfer/kamal/router/tests.clj
@@ -7,7 +7,7 @@
             [hiposfer.kamal.router.algorithms.dijkstra :as dijkstra]
             [hiposfer.kamal.router.algorithms.protocols :as np]
             [hiposfer.kamal.router.core :as router]
-            [hiposfer.kamal.router.generators :as fake-area]
+            [hiposfer.kamal.router.generators :as sim-area]
             [hiposfer.kamal.router.transit :as transit]
             [hiposfer.kamal.router.directions :as dir]
             [hiposfer.kamal.server.specs.directions :as dataspecs]
@@ -133,7 +133,7 @@
 (defspec deterministic
   100; tries
   (prop/for-all [size (gen/large-integer* {:min 10 :max 20})]
-    (let [graph    (fake-area/graph size)
+    (let [graph    (sim-area/osm-gen size)
           src      (:db/id (rand-nth (nodes graph)))
           dst      (:db/id (rand-nth (nodes graph)))
           router   (->PedestrianDatascriptRouter graph)
@@ -150,7 +150,7 @@
 (defspec monotonic
   100; tries
   (prop/for-all [size (gen/large-integer* {:min 10 :max 20})]
-     (let [graph    (fake-area/graph size)
+     (let [graph    (sim-area/osm-gen size)
            src      (:db/id (rand-nth (nodes graph)))
            dst      (:db/id (rand-nth (nodes graph)))
            router   (->PedestrianDatascriptRouter graph)
@@ -167,7 +167,7 @@
 (defspec symmetry
   100; tries
   (prop/for-all [size (gen/large-integer* {:min 10 :max 20})]
-    (let [graph    (fake-area/graph size)
+    (let [graph    (sim-area/osm-gen size)
           src      (:db/id (rand-nth (nodes graph)))
           router   (->PedestrianDatascriptRouter graph)
           result   (dijkstra/shortest-path router #{src} src)]
@@ -182,7 +182,7 @@
 #_(defspec components
     100; tries
     (prop/for-all [size (gen/large-integer* {:min 10 :max 20})]
-      (let [graph   (fake-area/graph size)
+      (let [graph   (sim-area/osm-gen size)
             router  (->PedestrianDatascriptRouter graph)
             r1      (alg/looners graph router)
             graph2  (data/db-with graph (for [i r1 ] [:db.fn/retractEntity (:db/id i)]))
@@ -200,7 +200,7 @@
 #_(defspec routable-components
     100; tries
     (prop/for-all [size (gen/large-integer* {:min 10 :max 20})]
-      (let [graph   (fake-area/graph size)
+      (let [graph   (sim-area/osm-gen size)
             router  (->PedestrianDatascriptRouter graph)
             r1      (alg/looners graph router)
             graph2  (data/db-with graph (for [i r1 ] [:db.fn/retractEntity (:db/id i)]))
@@ -215,7 +215,7 @@
 (defspec generative-directions
   100; tries
   (prop/for-all [size (gen/large-integer* {:min 10 :max 20})]
-    (let [graph    (fake-area/graph size)
+    (let [graph    (sim-area/osm-gen size)
           request  (gen/generate (s/gen ::dataspecs/params))
           conn     (data/conn-from-db graph)
           _        (alter-meta! conn assoc :area/graph (graph/create graph))


### PR DESCRIPTION
- fixes #275 - we group the edges in advance to avoid duplications
- fixes #276 - moves part of the preprocessing to the postprocessing
- this way we can avoid increasing the size of the EDN dump
- we can also quickly discard the edge/arc relations for Datascript since we put those in the int-graph anyway
- this saves us around 25 MB of memory. Not much but considering that the total for frankfurt was around 115 MB, it would mean a saving of around 30%. It would probably be worth in the long run