### PR TITLE
Dijkstra specs

### DIFF
--- a/src/hiposfer/kamal/dev.clj
+++ b/src/hiposfer/kamal/dev.clj
@@ -53,10 +53,10 @@
   []
   (stop!)
   (init!)
-  (clojure.spec.test.alpha/instrument)
   (alter-var-root #'s/*explain-out* (constantly custom-printer))
-  (set! *warn-on-reflection* true)
-  (set! *print-length* 50)
+  (clojure.spec.test.alpha/instrument)
+  (alter-var-root #'*warn-on-reflection* (constantly true))
+  (alter-var-root #'*print-length* (constantly 50))
   (start!))
 
 (defn refresh!
@@ -66,6 +66,5 @@
   (repl/refresh :after 'hiposfer.kamal.dev/go!))
 
 ;(refresh!)
-
 ;(type @(first @(:networks (:router system))))
 ;(take 10 @(first @(:networks (:router system))))

--- a/src/hiposfer/kamal/router/algorithms/dijkstra.clj
+++ b/src/hiposfer/kamal/router/algorithms/dijkstra.clj
@@ -147,7 +147,7 @@
 (s/def ::router #(satisfies? np/Dijkstra %))
 (s/def ::start (s/or :entity (s/and some? #(not (vector? %)))
                      :pair   (s/tuple some? np/valuable?)))
-(s/def ::comparator #(instance? Comparator %))
+(s/def ::comparator (s/or :default nil? :instance #(instance? Comparator %)))
 
 ;; note: SimpleImmutableEntry is not accepted by s/tuple :(
 (s/def ::trace (s/and map-entry?
@@ -165,6 +165,5 @@
         :args (s/cat :router ::router
                      :start ::start
                      :dst  nil?
-                     :comparator (s/? (s/or :default nil?
-                                            :instance #(instance? Comparator %))))
+                     :comparator (s/? ::comparator))
         :ret int?)

--- a/src/hiposfer/kamal/router/algorithms/dijkstra.clj
+++ b/src/hiposfer/kamal/router/algorithms/dijkstra.clj
@@ -164,6 +164,6 @@
 (s/fdef shortest-path
         :args (s/cat :router ::router
                      :start ::start
-                     :dst  nil?
+                     :dst  some?
                      :comparator (s/? ::comparator))
         :ret int?)

--- a/src/hiposfer/kamal/router/algorithms/dijkstra.clj
+++ b/src/hiposfer/kamal/router/algorithms/dijkstra.clj
@@ -1,6 +1,7 @@
 (ns hiposfer.kamal.router.algorithms.dijkstra
-  (:require [hiposfer.kamal.router.algorithms.protocols :as np])
-  (:import (java.util HashMap Map AbstractMap$SimpleImmutableEntry)
+  (:require [hiposfer.kamal.router.algorithms.protocols :as np]
+            [clojure.spec.alpha :as s])
+  (:import (java.util HashMap Map AbstractMap$SimpleImmutableEntry Comparator)
            (clojure.lang Seqable IReduceInit IReduce Sequential)
            (org.teneighty.heap FibonacciHeap Heap Heap$Entry)))
 
@@ -142,3 +143,28 @@
                            (when (= dst (key (first value)))
                              (reduced value)))]
      (reduce rf nil graph-traversal))))
+
+(s/def ::router #(satisfies? np/Dijkstra %))
+(s/def ::start (s/or :entity (s/and some? #(not (vector? %)))
+                     :pair   (s/tuple some? np/valuable?)))
+(s/def ::comparator #(instance? Comparator %))
+
+;; note: SimpleImmutableEntry is not accepted by s/tuple :(
+(s/def ::trace (s/and map-entry?
+                      (fn [[k v]] (and (some? k) (np/valuable? v)))))
+(s/def ::path (s/coll-of ::trace :min-count 1 :kind sequential?))
+
+(s/fdef view
+        :args (s/cat :router ::router
+                     :start ::start
+                     :comparator (s/? (s/or :default nil?
+                                            :instance #(instance? Comparator %))))
+        :ret #(instance? Dijkstra %))
+
+(s/fdef shortest-path
+        :args (s/cat :router ::router
+                     :start ::start
+                     :dst  nil?
+                     :comparator (s/? (s/or :default nil?
+                                            :instance #(instance? Comparator %))))
+        :ret int?)

--- a/src/hiposfer/kamal/router/algorithms/protocols.clj
+++ b/src/hiposfer/kamal/router/algorithms/protocols.clj
@@ -32,6 +32,8 @@
   (relax [this arc trail]
     "attempts to relax node following trail path. Returns a Valuable implementation"))
 
+(defn valuable? [o] (satisfies? Valuable o))
+
 (defn edge? [o] (and (satisfies? Arc o)
                      (satisfies? Bidirectional o)))
 


### PR DESCRIPTION
- fixes #165 
- spec definitions added to `dijkstra/view` and `dijkstra/shortest-path`

WARNING: since the router is one fo the arguments, the output of a failed spec is a huge string containing all elements of the graph :/ ... I couldnt find a way to avoid this for the moment; maybe later