### PR TITLE
try to solve heroku jvm metrics

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,44 +2,63 @@
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"
-            :url "https://github.com/hiposfer/kamal/blob/master/LICENSE"}
+            :url  "https://github.com/hiposfer/kamal/blob/master/LICENSE"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/data.xml "0.0.8"] ; parse xml lazily
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 ;; parse xml lazily
+                 [org.clojure/data.xml "0.0.8"]
+                 ;; abstraction over ring servers - syntactic sugar
                  [compojure "1.6.1"]
                  [ring/ring-json "0.4.0"]
-                 [ring/ring-jetty-adapter "1.7.0"]
-                 [metosin/ring-http-response "0.9.0"] ;; human names for http codes
-                 [ring-middleware-accept "2.0.3"] ;; http accept header
+                 [ring/ring-jetty-adapter "1.7.1" :exclusions [ring/ring-core
+                                                               ring/ring-codec
+                                                               commons-io
+                                                               clj-time
+                                                               commons-codec]]
+                 [metosin/ring-http-response "0.9.1" :exclusions [ring/ring-core
+                                                                  ring/ring-codec
+                                                                  commons-io
+                                                                  clj-time
+                                                                  commons-codec]]
+                 ;; http content negotiation - accept header
+                 [ring-middleware-accept "2.0.3"]
                  [hiposfer/geojson.specs "0.2.0"]
                  [hiposfer/gtfs.edn "0.1.1"]
-                 [com.stuartsierra/component "0.3.2"] ;; system builder and resource management
-                 [org.teneighty/java-heaps "1.0.0"] ;; for performance in dijkstra routing
-                 [org.clojure/data.csv "0.1.4"] ;; for gtfs parsing
-                 [datascript "0.16.6"]
-                 [org.clojure/data.int-map "0.2.4"] ;; fast int maps
-                 [ch.hsr/geohash "1.3.0"]] ;; for nearest neighbour search
+                 ;; system builder and resource management
+                 [com.stuartsierra/component "0.3.2"]
+                 ;; for performance in dijkstra routing
+                 [org.teneighty/java-heaps "1.0.0"]
+                 ;; for gtfs parsing
+                 [org.clojure/data.csv "0.1.4"]
+                 [datascript "0.17.1"]
+                 ;; fast int maps - for faster dijkstra routing
+                 [org.clojure/data.int-map "0.2.4"]
+                 ;; for nearest neighbour search
+                 [ch.hsr/geohash "1.3.0"]
+                 ;; needed for heroku - JVM platform metrics
+                 ;; otherwise we get - Exception in thread "heroku-java-metrics-agent" java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.JavaType.isReferenceType()Z
+                 [com.fasterxml.jackson.core/jackson-databind "2.6.4"]]
   ;; preprocessor - env vars are not passed along, so better run manually
   ;; ["trampoline" "run" "-m" "hiposfer.kamal.preprocessor"]}
-  :profiles {:dev {:dependencies [[criterium "0.4.4"]  ;; benchmark
-                                  [expound "0.7.1"]
-                                  [org.clojure/test.check "0.9.0"] ;; generators
-                                  [org.clojure/tools.namespace "0.2.11"]]
-                   :plugins [[jonase/eastwood "0.2.9"]]
-                   :eastwood {:config-files ["resources/eastwood.clj"]}}
-             :release {:aot [hiposfer.kamal.core] ;; compile the entry point and all of its dependencies}
-                       :main hiposfer.kamal.core
-                       :uberjar-name "kamal.jar"
-                       :jar-exclusions [#".*\.gz" #".*\.zip"]
+  :profiles {:dev     {:dependencies [[criterium "0.4.4"]   ;; benchmark
+                                      [expound "0.7.1"]
+                                      [org.clojure/test.check "0.9.0"] ;; generators
+                                      [org.clojure/tools.namespace "0.2.11"]]
+                       :plugins      [[jonase/eastwood "0.2.9"]]
+                       :eastwood     {:config-files ["resources/eastwood.clj"]}}
+             :release {:aot                [hiposfer.kamal.core] ;; compile the entry point and all of its dependencies}
+                       :main               hiposfer.kamal.core
+                       :uberjar-name       "kamal.jar"
+                       :jar-exclusions     [#".*\.gz" #".*\.zip"]
                        :uberjar-exclusions [#".*\.gz" #".*\.zip"]
-                       :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}}
-  :test-selectors {:default (fn [m] (not (some #{:benchmark :integration} (keys m))))
-                   :benchmark :benchmark
+                       :jvm-opts           ["-Dclojure.compiler.direct-linking=true"]}}
+  :test-selectors {:default     (fn [m] (not (some #{:benchmark :integration} (keys m))))
+                   :benchmark   :benchmark
                    :integration :integration}
   ;;FIXME: https://github.com/technomancy/leiningen/issues/2173
   :monkeypatch-clojure-test false
-  :repositories [["releases"  {:url      "https://clojars.org/repo"
-                               :username :env/clojars_username
-                               :password :env/clojars_password
-                               :sign-releases false}]]
-  :deploy-repositories [["releases"  :releases]])
+  :repositories [["releases" {:url           "https://clojars.org/repo"
+                              :username      :env/clojars_username
+                              :password      :env/clojars_password
+                              :sign-releases false}]]
+  :deploy-repositories [["releases" :releases]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/kamal "0.20.3"
+(defproject hiposfer/kamal "0.20.4"
   :description "An application that provides routing based on external sources and OSM data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"


### PR DESCRIPTION
- clojure version bumped 
- datascript version bumped
- jackson databind added to solve heroku lack of metrics

from the logs in papertrail
```
Dec 16 14:45:50 kamal-live app/web.1: Exception in thread "heroku-java-metrics-agent" java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.JavaType.isReferenceType()Z 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.fasterxml.jackson.databind.ser.BeanSerializerFactory._createSerializer2(BeanSerializerFactory.java:202) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.fasterxml.jackson.databind.ser.BeanSerializerFactory.createSerializer(BeanSerializerFactory.java:165) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.fasterxml.jackson.databind.SerializerProvider._createUntypedSerializer(SerializerProvider.java:1388) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.fasterxml.jackson.databind.SerializerProvider._createAndCacheUntypedSerializer(SerializerProvider.java:1336) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.fasterxml.jackson.databind.SerializerProvider.findValueSerializer(SerializerProvider.java:510) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.fasterxml.jackson.databind.SerializerProvider.findTypedValueSerializer(SerializerProvider.java:713) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:308) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.fasterxml.jackson.databind.ObjectWriter$Prefetch.serialize(ObjectWriter.java:1396) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.fasterxml.jackson.databind.ObjectWriter._configAndWriteValue(ObjectWriter.java:1120) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.fasterxml.jackson.databind.ObjectWriter.writeValueAsString(ObjectWriter.java:993) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.heroku.agent.metrics.MetricsAgent$2.apply(MetricsAgent.java:58) 
Dec 16 14:45:50 kamal-live app/web.1: 	at com.heroku.agent.metrics.Poller$1.run(Poller.java:72) 
Dec 16 14:45:50 kamal-live app/web.1: 	at java.util.TimerThread.mainLoop(Timer.java:555) 
Dec 16 14:45:50 kamal-live app/web.1: 	at java.util.TimerThread.run(Timer.java:505) 
```

this seems to be a version conflict caused by our ring-json depedencies which require a lower version than the one heroku uses. This seems to be a wide spread problem 